### PR TITLE
chore: add project docs, editor config, and Claude instructions

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,20 @@
+# Project Understanding.
+
+It is important you go through the docs in `../docs/` directory to understand how to work within this project.
+
+## 1. Project structure
+
+We place all our documentation in `../docs/` directory.
+
+### 1 a. Understanding documentation files
+
+Each documentation file has a team-lead section and an agents section. The team-lead section starts with this comment `<!-- Start of team lead instructions  -->` and ends with this comment `<!--- End of team lead instructions -->`. This is where the team leader will place details about certain concepts in the project.
+
+The agents section starts with this comment `<!--- Start of Claude and agents instructions -->` and ends with
+`<!--- End of Claude and agents instructions -->`. This is where you can place related information that you think is important.
+
+The team lead section is the main source of truth and has the main instructions which must upheld to the letter, even if some instructions might conflict with the agents section. The team-lead section is only updated by the team leader so avoid writing anything within this section.
+
+### 1 b. Maintaining documentation.
+
+The team leader controls the structure of the documentation. Its is part of your responsibility to maintain the agents section. This section is good to low level details about concepts that you think will help you in future as you work on this project. These details should NOT conflict with the team leaders information.

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+[*.{js,json,yml}]
+charset = utf-8
+indent_style = space
+indent_size = 2

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+/.yarn/**            linguist-vendored
+/.yarn/releases/*    binary
+/.yarn/plugins/**/*  binary
+/.pnp.*              binary linguist-generated

--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+# autoshop

--- a/docs/build_systems.md
+++ b/docs/build_systems.md
@@ -1,0 +1,14 @@
+<!-- Start of team lead instructions  -->
+
+## Build Systems Guide
+
+This repo is a typescript/web project. We will use `yarn` as the package manager and `vite` as our build tool. For bundling our application, we will use [rspack](http://rspack.dev/api/)
+
+We will use strict typescript. This means avoiding the use of `any` expect in storybook files and unit tests.
+
+For testing our components, we use [storybook](https://storybook.js.org/docs) testing.
+
+<!--- End of team lead instructions -->
+
+<!--- Start of Claude and agents instructions -->
+<!--- End of Claude and agents instructions -->

--- a/docs/ci_pipelines.md
+++ b/docs/ci_pipelines.md
@@ -1,0 +1,12 @@
+<!-- Start of team lead instructions  -->
+
+## CI pipelines
+
+It is important that main remains healthy at all times. We will use continous integration to make sure of that. Here are the important build checks
+
+1. Every pull request must have a green TS build
+
+<!--- End of team lead instructions -->
+
+<!--- Start of Claude and agents instructions -->
+<!--- End of Claude and agents instructions -->

--- a/docs/data_layer.md
+++ b/docs/data_layer.md
@@ -1,0 +1,14 @@
+<!-- Start of team lead instructions  -->
+
+## Data layer
+
+Our application is built on react-router. The application is fully client side rendered. For state, we will use [zustand](https://zustand.docs.pmnd.rs/learn/getting-started/introduction) to store data. When it comes to store design, it is important to split stores to specific domains using slices, but we will have a single unified store.
+
+We have an API in `src/data/index.ts` that provides a clean interface for accessing data within stores to components.
+
+We're using mocked data for now, so we don't have remote calls. When the application boots, we load the mocked data into the store and update the UI. For now, the mock data is in `src/service/mocks.ts`.
+
+<!--- End of team lead instructions -->
+
+<!--- Start of Claude and agents instructions -->
+<!--- End of Claude and agents instructions -->

--- a/docs/storybooks.md
+++ b/docs/storybooks.md
@@ -1,0 +1,12 @@
+<!-- Start of team lead instructions  -->
+
+## Storybooks
+
+Storybooks are our main of testing the web components we write. See @web_components.md for more details. In terms of configuration, we will use the same configuration as our build system uses which is `rspack`. See @build_systems.md for more details.
+
+Any reusable code we have for storybooks will be placed in `src/storybooks/` and exposed using the `index.ts` file.
+
+<!--- End of team lead instructions -->
+
+<!--- Start of Claude and agents instructions -->
+<!--- End of Claude and agents instructions -->

--- a/docs/web_components.md
+++ b/docs/web_components.md
@@ -1,0 +1,14 @@
+<!-- Start of team lead instructions  -->
+
+## Web components
+
+We will be using React to create web components. Its important to isolate between presentation and data when writing components. All presentational components are placed in `src/components/` and exposed in an `index` file.
+
+For styling, we use [material UI](https://mui.com/material-ui/) exclusively, so avoid using any other styling library.
+
+Each components, should have a respective storybook file covering the component. See the @data_layer.md file to understand the structure of our data layer.
+
+<!--- End of team lead instructions -->
+
+<!--- Start of Claude and agents instructions -->
+<!--- End of Claude and agents instructions -->


### PR DESCRIPTION
## Summary
- Adds all team lead documentation under `docs/` (build systems, CI pipelines, data layer, storybooks, web components)
- Adds `.editorconfig` and `.gitattributes` for consistent editor and git behaviour
- Adds `.claude/CLAUDE.md` — project instructions for Claude Code agents

## Notes
- No executable code changes
- `docs/ci_pipelines.md` is the basis for issue #15 (GitHub Actions CI setup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)