### PR TITLE
chore: enable headless agent execution

### DIFF
--- a/.claude/agents/architect.md
+++ b/.claude/agents/architect.md
@@ -2,6 +2,7 @@
 name: architect
 description: The reference agent with deep repo context. Handles architecture decisions, cross-cutting design questions, and is consulted by other agents when they are unsure about structure, patterns, or scope. Also answers direct architecture questions from the user.
 allowed-tools: Bash, Read, Glob, Grep
+permissionMode: bypassPermissions
 ---
 
 You are the **Architect Agent** in the fellowship-of-agents team.

--- a/.claude/agents/bug-fixer.md
+++ b/.claude/agents/bug-fixer.md
@@ -2,6 +2,7 @@
 name: bug-fixer
 description: Diagnoses and fixes bugs. Spawn this agent when a specific bug needs investigation — it will trace the issue, identify the root cause, and apply a fix. Give it the bug description, error message, or failing behaviour.
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep
+permissionMode: bypassPermissions
 ---
 
 You are the **Bug Fixer Agent** in the fellowship-of-agents team.

--- a/.claude/agents/devops.md
+++ b/.claude/agents/devops.md
@@ -2,6 +2,7 @@
 name: devops
 description: The repo health and developer experience agent. Responsible for keeping the codebase in good shape — CI/CD pipelines, build systems, tooling, dependency hygiene, and developer workflows. Spawn this agent for anything that affects how the repo runs, builds, or is maintained rather than what it produces.
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep
+permissionMode: bypassPermissions
 ---
 
 You are the **DevOps Agent** in the fellowship-of-agents team.

--- a/.claude/agents/slack-agent.md
+++ b/.claude/agents/slack-agent.md
@@ -2,6 +2,7 @@
 name: slack-agent
 description: Tracks and answers questions about Slack conversations in #all-agents. Any agent can consult the slack-agent to get context about what has been discussed, decided, or requested in the channel before starting work.
 allowed-tools: Bash
+permissionMode: bypassPermissions
 ---
 
 You are the **Slack Agent** in the fellowship-of-agents team.

--- a/.claude/agents/triage.md
+++ b/.claude/agents/triage.md
@@ -2,6 +2,7 @@
 name: triage
 description: Handles GitHub issue triage — scanning new issues, enriching them with context from PRs and codebase, applying labels, and identifying blockers. Spawn this agent when asked to triage issues or prepare the backlog.
 allowed-tools: Bash, Read, Glob, Grep
+permissionMode: bypassPermissions
 ---
 
 You are the **Triage Agent** in the fellowship-of-agents team.

--- a/.claude/agents/ui.md
+++ b/.claude/agents/ui.md
@@ -2,6 +2,7 @@
 name: ui
 description: Handles frontend work — components, styling, design implementation, and UI patterns. Spawn this agent for tasks involving source files in src/components/, design system tokens, Figma implementation, or visual/interaction concerns.
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep
+permissionMode: bypassPermissions
 ---
 
 You are the **UI Agent** in the fellowship-of-agents team.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,17 @@
 {
   "env": {
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
+  },
+  "permissions": {
+    "allow": [
+      "Bash(*)",
+      "Read(**)",
+      "Edit(**)",
+      "Write(**)",
+      "Glob(*)",
+      "Grep(*)",
+      "WebFetch(*)",
+      "WebSearch(*)"
+    ]
   }
 }


### PR DESCRIPTION
## Summary

Fixes agents stopping and asking for Bash permission despite `mode: bypassPermissions` being set on spawn.

**Root cause:** Two layers of permission control both need to be satisfied:
1. The project's `settings.json` must pre-approve tools via `permissions.allow`
2. Each agent definition must declare `permissionMode: bypassPermissions` in its frontmatter

**Changes:**
- `.claude/settings.json` — added `permissions.allow` for `Bash(*)`, `Read(**)`, `Edit(**)`, `Write(**)`, `Glob(*)`, `Grep(*)`, `WebFetch(*)`, `WebSearch(*)`
- All 6 agent definitions — added `permissionMode: bypassPermissions` to frontmatter (`devops`, `ui`, `bug-fixer`, `triage`, `architect`, `slack-agent`)

## Test plan
- [ ] Spawn a devops agent and confirm it runs git/gh/python Bash commands without any permission prompts
- [ ] Smoke test: agent posts to Slack autonomously from start to finish

🤖 Generated with [Claude Code](https://claude.com/claude-code)