### PR TITLE
feat(docs): integrate Obsidian vault for agent design documentation

### DIFF
--- a/.claude/skills/architect-context/SKILL.md
+++ b/.claude/skills/architect-context/SKILL.md
@@ -57,9 +57,22 @@ for i in backlog:
 "
 ```
 
-### Step 6 — Confirm context is loaded
+### Step 6 — Read design documents from the Obsidian vault
 
-After completing all steps, post to Slack that you are ready:
+The Obsidian vault (`Fellowship-Of-Agents`) contains design documents and decision records written by agents before or during implementation. These are the canonical record of approved approaches and open questions.
+
+Read all documents in the vault to collect prior decisions:
+
+1. Use `mcp__obsidian__list_directory` on `Design/` to list all design docs.
+2. Use `mcp__obsidian__list_directory` on `Status/` to read the project status.
+3. Use `mcp__obsidian__read_note` to read each document in full.
+4. Pay special attention to **Recommended approach**, **Open questions**, and **Acceptance criteria** sections.
+
+These documents take precedence over inferred context when they address a specific topic.
+
+### Step 7 — Confirm context is loaded
+
+After completing all steps (including reading vault documents), post to Slack that you are ready:
 
 ```python
 import urllib.request, json, re, os

--- a/.claude/skills/continue-issue/SKILL.md
+++ b/.claude/skills/continue-issue/SKILL.md
@@ -64,7 +64,11 @@ Based on the issue type and PR diff, re-read the files that were previously modi
 git diff main --name-only
 ```
 
-### Step 6 — Confirm understanding before acting
+### Step 6 — Check the Obsidian vault for design docs
+
+Search the vault for any design documents related to this issue. Use the `/read-doc` skill with the issue title or topic. If a design doc exists, read it in full — it contains the approved approach and acceptance criteria that guide your implementation.
+
+### Step 7 — Confirm understanding before acting
 
 Post to Slack summarising:
 1. What was done in the previous session (PR summary)
@@ -73,11 +77,11 @@ Post to Slack summarising:
 
 Use the relevant agent's Slack identity (see `.claude/agents/`) before proceeding.
 
-### Step 7 — Implement the review feedback
+### Step 8 — Implement the review feedback
 
 Apply all changes requested in the review comments. Push to the existing branch when done.
 
-### Step 8 — Confirm CI checks are green
+### Step 9 — Confirm CI checks are green
 
 After pushing, wait for all GitHub Actions checks to complete:
 
@@ -94,7 +98,7 @@ gh pr checks <PR-number> --repo ngareleo/fellowship-of-agents
 gh run view --repo ngareleo/fellowship-of-agents --log-failed
 ```
 
-### Step 9 — Post completion update to Slack
+### Step 10 — Post completion update to Slack
 
 Once all CI checks pass, post to Slack as the relevant agent with:
 - Summary of what review feedback was addressed

--- a/.claude/skills/read-doc/SKILL.md
+++ b/.claude/skills/read-doc/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: read-doc
+description: Search and read design documents from the Obsidian vault. Use this to load context from prior decisions before starting or continuing work.
+disable-model-invocation: false
+argument-hint: "<topic or search query>"
+allowed-tools: Bash, Read, Glob, Grep
+---
+
+You are looking up documentation in the Obsidian vault for: `$ARGUMENTS`
+
+Work through each step in order.
+
+---
+
+### Step 1 — Search the vault
+
+Use the `mcp__obsidian__search_notes` tool to search for relevant documents:
+
+- Query: `$ARGUMENTS`
+- Set `searchContent: true` and `searchFrontmatter: true`
+- Retrieve up to 10 results (`limit: 10`)
+
+Also list the `Design/` and `Status/` folders to spot documents that might not surface via search:
+
+Use `mcp__obsidian__list_directory` with path `Design/` and then `Status/`.
+
+### Step 2 — Read relevant documents
+
+For each document that looks relevant based on title or search snippet:
+
+- Use `mcp__obsidian__read_note` to read the full content.
+- Pay attention to the **Recommended approach**, **Open questions**, and **Acceptance criteria** sections.
+- Note the `date` frontmatter — prefer newer documents when they conflict with older ones.
+
+### Step 3 — Summarise what you found
+
+After reading all relevant documents, summarise:
+
+1. **Relevant decisions already made** — approved approaches or conventions.
+2. **Open questions** — anything still unresolved in existing docs.
+3. **Gaps** — topics with no existing documentation.
+
+If there are gaps or open questions that block your current task, use `/write-doc` to create a new design document before proceeding.
+
+### Step 4 — Proceed with context loaded
+
+You now have design context loaded. Continue with your original task, applying the decisions and conventions found in the vault.

--- a/.claude/skills/start-issue/SKILL.md
+++ b/.claude/skills/start-issue/SKILL.md
@@ -67,19 +67,30 @@ Based on the issue type, scan and read the files most likely to be touched:
 
 Use `Glob` and `Grep` to locate the exact files, then `Read` them.
 
-### Step 7 — Confirm understanding
+### Step 7 — Check the Obsidian vault for existing design docs
+
+Before writing any code, search the vault for prior design decisions related to this issue. Use the `/read-doc` skill with the issue title or topic as the query. This surfaces any approved approaches, conventions, or open questions from previous design sessions.
+
+### Step 8 — Confirm understanding
 
 Print a brief summary back to the user covering:
 
 1. **What the issue asks for** — one or two sentences.
 2. **Files likely to be modified** — a short list.
-3. **Open questions** — anything unclear before starting work (missing context, ambiguous requirements, potential conflicts with other open issues).
+3. **Design docs found** — any relevant vault documents and their key decisions.
+4. **Open questions** — anything unclear before starting work (missing context, ambiguous requirements, potential conflicts with other open issues).
 
-Do not begin implementing until the user confirms or answers any open questions.
+**If there are significant open questions that cannot be resolved from existing docs or code**, do not guess. Instead:
+
+- Use the `/write-doc` skill to create a design document exploring the options.
+- Post the doc link to Slack and tag `@architect` for review.
+- **Stop work** — the team lead will re-spawn you once a decision is made.
+
+Only begin implementing once all open questions are resolved.
 
 ---
 
-### Step 8 — Open a PR
+### Step 10 — Open a PR
 
 When implementation is complete, create the pull request:
 
@@ -100,7 +111,7 @@ EOF
 
 Note the PR number returned — you will need it in the next step.
 
-### Step 9 — Confirm CI checks are green
+### Step 11 — Confirm CI checks are green
 
 Wait for all GitHub Actions checks on the PR to complete:
 
@@ -117,7 +128,7 @@ gh pr checks <PR-number> --repo ngareleo/fellowship-of-agents
 gh run view --repo ngareleo/fellowship-of-agents --log-failed
 ```
 
-### Step 10 — Mark ready for review and notify
+### Step 12 — Mark ready for review and notify
 
 Once all CI checks pass:
 

--- a/.claude/skills/write-doc/SKILL.md
+++ b/.claude/skills/write-doc/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: write-doc
+description: Write a design or decision document to the Obsidian vault and share the link on Slack. Use this when you are unsure how to proceed on a complex task and need to think through the approach before implementing.
+disable-model-invocation: false
+argument-hint: "<topic or issue number>"
+allowed-tools: Bash, Read, Glob, Grep
+---
+
+You are writing a design document for: `$ARGUMENTS`
+
+Work through each step in order.
+
+---
+
+### Step 1 — Gather context
+
+Collect all relevant context before writing:
+
+- Read the issue (if a number was given):
+
+```bash
+/usr/bin/gh issue view $ARGUMENTS --repo ngareleo/fellowship-of-agents --json title,body,labels,comments
+```
+
+- Read any related docs from `docs/`:
+
+```bash
+ls docs/
+```
+
+- Search the Obsidian vault for any existing documents on this topic using the `mcp__obsidian__search_notes` tool with a relevant query.
+
+- Read relevant source files using `Glob` and `Read` if implementation context is needed.
+
+### Step 2 — Draft the document
+
+Write a structured design document covering:
+
+1. **Problem** — What is the challenge or open question?
+2. **Context** — Relevant code, constraints, or prior decisions.
+3. **Options considered** — At least two approaches, with trade-offs for each.
+4. **Recommended approach** — Which option and why.
+5. **Open questions** — Anything still unresolved that needs human or architect input.
+6. **Acceptance criteria** — How we will know the implementation is correct.
+
+### Step 3 — Save to Obsidian
+
+Save the document to the vault under `Design/` using the `mcp__obsidian__write_note` tool:
+
+- Path: `Design/<slug>.md` where `<slug>` is a lowercase-hyphenated title (e.g. `Design/mock-data-service.md`)
+- Include frontmatter: `date`, `issue` (if applicable), `tags: ["design"]`, `author` (your agent name)
+- Content: the full document from Step 2
+
+### Step 4 — Post to Slack
+
+Share the document on Slack so the team lead and architect can review it:
+
+```python
+import urllib.request, json, re, os
+src = open(os.path.expanduser('~/.zshrc')).read()
+token = re.search(r'SLACK_BOT_TOKEN="([^"]+)"', src).group(1)
+payload = json.dumps({
+    'channel': 'C0AHMFTFQ95',
+    'text': (
+        ':memo: *Design doc created:* `Design/<slug>.md`\n'
+        '*Topic:* $ARGUMENTS\n'
+        '*Summary:* <one sentence summary of the recommended approach>\n'
+        'Waiting for feedback before implementing. @architect please review.'
+    ),
+    'username': '<Your Agent Name>',
+    'icon_emoji': '<your emoji>',
+}).encode()
+req = urllib.request.Request(
+    'https://slack.com/api/chat.postMessage',
+    data=payload,
+    headers={'Authorization': 'Bearer ' + token, 'Content-Type': 'application/json'}
+)
+json.loads(urllib.request.urlopen(req).read())
+```
+
+Replace `<Your Agent Name>` and `<your emoji>` with your agent identity from `.claude/CLAUDE.md`.
+
+### Step 5 — Stop and wait
+
+Do **not** begin implementation. Stop here. The team lead or architect will review the document and either approve the approach or leave feedback. You will be re-spawned via `/continue-issue` once a decision is made.


### PR DESCRIPTION
## Summary

- Add `/write-doc` skill — agents write structured design docs (problem → options → recommendation → open questions → acceptance criteria) to the Obsidian vault under `Design/` and post the link to Slack tagging `@architect` before implementing
- Add `/read-doc` skill — agents search and read vault docs to load prior decisions before starting or resuming work; falls through to `/write-doc` if gaps remain
- Update `start-issue` — new Step 7 checks the vault for existing design docs; new Step 8 mandates creating a design doc (and stopping) rather than guessing when open questions can't be resolved from code or existing docs
- Update `continue-issue` — new Step 6 checks the vault for design docs before re-implementing after a review
- Update `architect-context` — new Step 6 reads all `Design/` and `Status/` vault documents; vault docs take precedence over inferred context when they address a specific topic

## Why

Agents were proceeding with implementation even when requirements were ambiguous. This introduces a structured "doc-first" gate: complex or unclear tasks must produce a design document and architect sign-off before any code is written, reducing wasted PRs and review cycles.

🤖 Generated by Fellowship Team Lead