### PR TITLE
feat(ci): add Chromatic workflow for Storybook PR preview links

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,0 +1,42 @@
+name: Chromatic Storybook Preview
+
+# NOTE: This workflow requires a CHROMATIC_PROJECT_TOKEN secret to be set in
+# GitHub repo Settings > Secrets and variables > Actions.
+# Obtain the token from https://www.chromatic.com after connecting the repo.
+
+on:
+  push:
+    branches:
+      - "**"
+  pull_request:
+
+jobs:
+  chromatic:
+    name: Publish to Chromatic
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # Chromatic needs full git history to establish baselines for visual diffing
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Enable Corepack (Yarn 4)
+        run: corepack enable
+
+      - name: Install dependencies
+        # Assumes node-modules linker is configured via .yarnrc.yml (nodeLinker: node-modules)
+        run: corepack yarn install --immutable
+
+      - name: Publish to Chromatic
+        uses: chromaui/action@latest
+        with:
+          # Project token from https://www.chromatic.com — store as a repo secret:
+          # GitHub repo > Settings > Secrets and variables > Actions > New repository secret
+          # Name: CHROMATIC_PROJECT_TOKEN
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.1.4",
+    "chromatic": "^15.2.0",
     "storybook": "^10.2.14",
     "storybook-react-rsbuild": "^3.3.0",
     "typescript": "^5.9.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2679,6 +2679,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"chromatic@npm:^15.2.0":
+  version: 15.2.0
+  resolution: "chromatic@npm:15.2.0"
+  peerDependencies:
+    "@chromatic-com/cypress": ^0.*.* || ^1.0.0
+    "@chromatic-com/playwright": ^0.*.* || ^1.0.0
+  peerDependenciesMeta:
+    "@chromatic-com/cypress":
+      optional: true
+    "@chromatic-com/playwright":
+      optional: true
+  bin:
+    chroma: dist/bin.js
+    chromatic: dist/bin.js
+    chromatic-cli: dist/bin.js
+  checksum: 10c0/b46c9e288236c76128935373ca90eda0127eb604a0431ba25c4600e952fc2bba414dbc3268513be7cc35b9d0ffff8566ca95e838bc9d4341940a99ef33a5808b
+  languageName: node
+  linkType: hard
+
 "cjs-module-lexer@npm:^2.2.0":
   version: 2.2.0
   resolution: "cjs-module-lexer@npm:2.2.0"
@@ -3412,6 +3431,7 @@ __metadata:
     "@types/react": "npm:^19.2.14"
     "@types/react-dom": "npm:^19.2.3"
     "@vitejs/plugin-react": "npm:^5.1.4"
+    chromatic: "npm:^15.2.0"
     react: "npm:^19.2.4"
     react-dom: "npm:^19.2.4"
     react-router: "npm:^7.13.1"


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/chromatic.yml` that publishes Storybook to Chromatic on every push and pull request
- Uses `actions/checkout@v4` with `fetch-depth: 0` so Chromatic can establish visual diff baselines from full git history
- Uses `chromaui/action@latest` (official Chromatic GitHub Action)
- Adds `chromatic@^15.2.0` as a dev dependency
- Assumes `nodeLinker: node-modules` in `.yarnrc.yml` (being configured by a parallel agent)

## Setup required

After merging, a repo admin must add the Chromatic project token as a secret:

1. Go to [chromatic.com](https://www.chromatic.com) and connect the `ngareleo/fellowship-of-agents` repo
2. Copy the project token from the Chromatic dashboard
3. In GitHub: **Settings > Secrets and variables > Actions > New repository secret**
   - Name: `CHROMATIC_PROJECT_TOKEN`
   - Value: (paste token from Chromatic)

Once set, every PR will get a Chromatic preview link with visual diffs posted as a status check.

## Test plan

- [ ] Confirm `chromatic` appears in `devDependencies` in `package.json`
- [ ] Confirm `.github/workflows/chromatic.yml` exists and has correct trigger conditions (`push` on all branches + `pull_request`)
- [ ] After adding `CHROMATIC_PROJECT_TOKEN` secret, open a test PR and verify the Chromatic check runs and posts a preview URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)