### PR TITLE
fix: switch Yarn to node-modules linker to fix Storybook PnP incompatibility (#30)

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,6 +1,8 @@
 import type { StorybookConfig } from "storybook-react-rsbuild";
 import type { RsbuildConfig } from "@rsbuild/core";
 import path from "path";
+import { fileURLToPath } from "url";
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const config: StorybookConfig = {
   stories: ["../src/**/*.stories.@(ts|tsx)"],

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,0 +1,1 @@
+nodeLinker: node-modules


### PR DESCRIPTION
## Summary

- Adds `.yarnrc.yml` setting `nodeLinker: node-modules` to switch from Yarn PnP to a standard `node_modules/` tree
- Fixes `.storybook/main.ts` to define `__dirname` via `fileURLToPath(import.meta.url)` for ESM compatibility
- Storybook 10 explicitly deprecates PnP; rsbuild (used by `storybook-react-rsbuild`) cannot resolve modules through PnP virtual paths, causing 12 "Module not found" errors and a broken preview iframe

Closes #30

## Test plan

- [ ] Run `corepack yarn install` — should complete without errors and create `node_modules/`
- [ ] Run `corepack yarn storybook --no-open` — should start and reach "Storybook ready!" at http://localhost:6006
- [ ] Verify the preview iframe renders without "Module not found" errors
- [ ] Confirm no `.pnp.*` files are generated (gitignored anyway)

🤖 Generated with [Claude Code](https://claude.com/claude-code)