### PR TITLE
feat(triage): cap UI issue assignments to one per dispatch cycle

### DIFF
--- a/.claude/agents/triage.md
+++ b/.claude/agents/triage.md
@@ -24,6 +24,10 @@ You are the **Triage Agent** in the fellowship-of-agents team.
 
 You have access to the `/triage` skill. Use it for standard triage runs.
 
+## UI assignment cap
+
+When recommending work to the team lead, **never suggest more than one `ui` issue per dispatch cycle**. Most pages share components; multiple agents working on UI simultaneously risk duplicating or conflicting on shared building blocks. Always pair the single `ui` issue with one `build-systems`, `code-quality`, or bug-fix item for the second slot. If no `ui` issue is ready, up to two non-UI items may be suggested.
+
 ## How to post to Slack
 
 ```python

--- a/.claude/skills/start-of-day/SKILL.md
+++ b/.claude/skills/start-of-day/SKILL.md
@@ -73,7 +73,13 @@ If there are untriaged issues, run `/triage` on them.
 
 ### Step 4 — Identify next work items
 
-From the `ready` issues, select up to 2–3 high-priority items to assign. Prefer issues with type labels (`ui`, `build-systems`, `code-quality`) that match available agents.
+From the `ready` issues, select items to assign following this rule:
+
+- **At most one `ui` issue** per dispatch cycle. Most pages share components; multiple agents working on UI simultaneously risk duplicating or conflicting on shared building blocks.
+- **Pair it with one non-UI item**: a `build-systems`, `code-quality`, or bug-fix issue for the second agent slot.
+- If no `ui` issue is ready, assign up to two non-UI items.
+
+Pick the highest-priority items within these constraints. Prefer issues that unblock the most downstream work.
 
 ### Step 5 — Spawn agents for priority work
 
@@ -82,6 +88,8 @@ For each selected issue, spawn the appropriate agent using the Agent tool. **Alw
 - `ui` label → spawn `ui` agent with prompt: `"Read .claude/agents/ui.md. Run /start-issue <N>."`
 - `build-systems` or `code-quality` label → spawn `devops` agent with prompt: `"Read .claude/agents/devops.md. Run /start-issue <N>."`
 - Bug reports → spawn `bug-fixer` agent
+
+**Never spawn more than one `ui` agent at a time.** If a `ui` agent is already running, skip additional `ui` issues and fill remaining slots with non-UI work.
 
 Example Agent tool call:
 ```

--- a/.claude/skills/triage/SKILL.md
+++ b/.claude/skills/triage/SKILL.md
@@ -192,3 +192,5 @@ Print a clear summary in this format:
 | N | ...   | ...      | #X, #Y |
 
 **Recommendation:** Pick the highest-priority `ready` item that unblocks the most downstream work. If two items share priority, prefer the one with more dependents.
+
+**UI assignment cap:** Assign **at most one `ui` issue** per dispatch cycle. Most pages share components, and multiple agents working on `ui` issues simultaneously risk duplicating or conflicting on the same building blocks. Pair the single `ui` issue with one `build-systems`, `code-quality`, or bug-fix item for the second agent slot.


### PR DESCRIPTION
## Summary

- Triage and start-of-day now enforce a hard cap of **one `ui` issue per dispatch cycle**
- The second agent slot must be filled by a `build-systems`, `code-quality`, or bug-fix item
- If a `ui` agent is already running, additional `ui` issues are skipped entirely

## Motivation

Most pages in the app share components. Without this cap, multiple agents working on different UI pages simultaneously risk implementing the same building blocks independently — leading to duplicate components, inconsistent patterns, and wasted work.

## Files changed

- `.claude/skills/triage/SKILL.md` — added UI cap to the Recommendation section
- `.claude/skills/start-of-day/SKILL.md` — Steps 4 & 5 rewritten to enforce the cap when selecting and spawning agents
- `.claude/agents/triage.md` — new "UI assignment cap" section so the triage agent surfaces the rule in its recommendations

## Test plan

- [ ] Run `/triage` and confirm the recommendation section mentions the UI cap
- [ ] Run `/start-of-day` with multiple `ui` issues ready — confirm only one `ui` agent is spawned

🤖 Generated with [Claude Code](https://claude.com/claude-code)