### PR TITLE
feat(ui): AppHeader navigation component + Storybook

### DIFF
--- a/src/components/AppHeader.stories.tsx
+++ b/src/components/AppHeader.stories.tsx
@@ -1,0 +1,76 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Box } from "@mui/material";
+import { AppHeader } from "./AppHeader";
+import { withTheme } from "~/storybooks";
+
+const meta: Meta<typeof AppHeader> = {
+  title: "Components/AppHeader",
+  component: AppHeader,
+  decorators: [
+    withTheme,
+    (Story) => (
+      <Box
+        sx={{
+          background: "linear-gradient(156.88deg, #0f172a 14.6%, #1e293b 50%, #1a2744 85.4%)",
+          minHeight: 120,
+          width: "100%",
+        }}
+      >
+        <Story />
+      </Box>
+    ),
+  ],
+  argTypes: {
+    onSignIn: { action: "onSignIn" },
+    onSearch: { action: "onSearch" },
+    onNavLinkClick: { action: "onNavLinkClick" },
+  },
+  parameters: {
+    layout: "fullscreen",
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof AppHeader>;
+
+/**
+ * Default desktop state — shows all nav links and action buttons.
+ */
+export const Default: Story = {};
+
+/**
+ * With custom navigation links.
+ */
+export const CustomNavLinks: Story = {
+  args: {
+    navLinks: [
+      { label: "Home", href: "/" },
+      { label: "Browse Cars", href: "/browse" },
+      { label: "Sell", href: "/sell" },
+    ],
+  },
+};
+
+/**
+ * Mobile viewport — hamburger menu replaces nav links.
+ * Open the Storybook canvas at a narrow width to see this state.
+ */
+export const Mobile: Story = {
+  parameters: {
+    viewport: {
+      defaultViewport: "mobile1",
+    },
+  },
+};
+
+/**
+ * Mobile viewport at a slightly larger narrow width.
+ */
+export const MobileWide: Story = {
+  parameters: {
+    viewport: {
+      defaultViewport: "mobile2",
+    },
+  },
+};

--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -1,0 +1,297 @@
+import { AppBar, Box, Button, IconButton, Stack, Toolbar, Typography, useMediaQuery, useTheme, Drawer, List, ListItemButton, ListItemText } from "@mui/material";
+import SearchIcon from "@mui/icons-material/Search";
+import MenuIcon from "@mui/icons-material/Menu";
+import CloseIcon from "@mui/icons-material/Close";
+import { useState } from "react";
+
+export type NavLink = {
+  label: string;
+  href: string;
+};
+
+export type AppHeaderProps = {
+  /** Navigation links to display in the header. */
+  navLinks?: NavLink[];
+  /** Called when the Sign In button is clicked. */
+  onSignIn?: () => void;
+  /** Called when the search icon button is clicked. */
+  onSearch?: () => void;
+  /** Called when a nav link is clicked — receives the href. */
+  onNavLinkClick?: (href: string) => void;
+};
+
+const DEFAULT_NAV_LINKS: NavLink[] = [
+  { label: "Buy a Car", href: "/" },
+  { label: "Sell Your Car", href: "/sell" },
+  { label: "Browse", href: "/browse" },
+  { label: "Financing", href: "/financing" },
+];
+
+export function AppHeader({
+  navLinks = DEFAULT_NAV_LINKS,
+  onSignIn,
+  onSearch,
+  onNavLinkClick,
+}: AppHeaderProps) {
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down("md"));
+  const [drawerOpen, setDrawerOpen] = useState(false);
+
+  const handleNavClick = (href: string) => {
+    onNavLinkClick?.(href);
+    setDrawerOpen(false);
+  };
+
+  return (
+    <>
+      <AppBar
+        position="static"
+        elevation={0}
+        sx={{
+          bgcolor: "transparent",
+          backgroundImage: "none",
+          borderBottom: "none",
+        }}
+      >
+        <Toolbar
+          sx={{
+            px: { xs: 2, md: 6 },
+            minHeight: { xs: 64, md: 72 },
+            justifyContent: "space-between",
+          }}
+        >
+          {/* Logo */}
+          <Box
+            component="a"
+            href="/"
+            onClick={(e) => {
+              e.preventDefault();
+              handleNavClick("/");
+            }}
+            sx={{
+              display: "flex",
+              alignItems: "center",
+              gap: 1,
+              textDecoration: "none",
+              cursor: "pointer",
+            }}
+          >
+            <Box
+              sx={{
+                width: 44,
+                height: 44,
+                bgcolor: "#2563eb",
+                borderRadius: "8px",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                flexShrink: 0,
+              }}
+            >
+              <Typography sx={{ fontSize: 20, lineHeight: 1 }}>
+                {"⏱"}
+              </Typography>
+            </Box>
+            <Typography
+              sx={{
+                fontFamily: "'Barlow', sans-serif",
+                fontWeight: 700,
+                fontSize: { xs: 22, md: 26 },
+                color: "#ffffff",
+                lineHeight: 1,
+              }}
+            >
+              AutoExchange
+            </Typography>
+          </Box>
+
+          {/* Desktop nav links */}
+          {!isMobile && (
+            <Stack direction="row" spacing={4} sx={{ flex: 1, justifyContent: "center" }}>
+              {navLinks.map((link) => (
+                <Typography
+                  key={link.href}
+                  component="a"
+                  href={link.href}
+                  onClick={(e) => {
+                    e.preventDefault();
+                    handleNavClick(link.href);
+                  }}
+                  sx={{
+                    color: "rgba(255,255,255,0.9)",
+                    fontWeight: 500,
+                    fontSize: 15,
+                    textDecoration: "none",
+                    cursor: "pointer",
+                    "&:hover": {
+                      color: "#ffffff",
+                    },
+                  }}
+                >
+                  {link.label}
+                </Typography>
+              ))}
+            </Stack>
+          )}
+
+          {/* Right side actions */}
+          <Stack direction="row" spacing={1.5} alignItems="center">
+            {/* Search icon */}
+            <IconButton
+              onClick={onSearch}
+              aria-label="Search"
+              sx={{
+                bgcolor: "rgba(255,255,255,0.1)",
+                color: "#ffffff",
+                width: 44,
+                height: 44,
+                borderRadius: "9999px",
+                "&:hover": {
+                  bgcolor: "rgba(255,255,255,0.2)",
+                },
+              }}
+            >
+              <SearchIcon sx={{ fontSize: 20 }} />
+            </IconButton>
+
+            {/* Sign In button (desktop only) */}
+            {!isMobile && (
+              <Button
+                variant="contained"
+                onClick={onSignIn}
+                sx={{
+                  bgcolor: "#2563eb",
+                  color: "#ffffff",
+                  fontWeight: 600,
+                  fontSize: 14,
+                  borderRadius: "8px",
+                  height: 45,
+                  px: 2.5,
+                  textTransform: "none",
+                  boxShadow: "none",
+                  "&:hover": {
+                    bgcolor: "#1d4ed8",
+                    boxShadow: "none",
+                  },
+                }}
+              >
+                Sign In
+              </Button>
+            )}
+
+            {/* Mobile hamburger */}
+            {isMobile && (
+              <IconButton
+                onClick={() => setDrawerOpen(true)}
+                aria-label="Open navigation menu"
+                sx={{ color: "#ffffff" }}
+              >
+                <MenuIcon />
+              </IconButton>
+            )}
+          </Stack>
+        </Toolbar>
+      </AppBar>
+
+      {/* Mobile drawer */}
+      <Drawer
+        anchor="right"
+        open={drawerOpen}
+        onClose={() => setDrawerOpen(false)}
+        PaperProps={{
+          sx: {
+            width: 280,
+            bgcolor: "#0f172a",
+            color: "#ffffff",
+          },
+        }}
+      >
+        <Box sx={{ p: 2 }}>
+          {/* Drawer header */}
+          <Box
+            sx={{
+              display: "flex",
+              justifyContent: "space-between",
+              alignItems: "center",
+              mb: 2,
+            }}
+          >
+            <Typography
+              sx={{
+                fontFamily: "'Barlow', sans-serif",
+                fontWeight: 700,
+                fontSize: 20,
+                color: "#ffffff",
+              }}
+            >
+              AutoExchange
+            </Typography>
+            <IconButton
+              onClick={() => setDrawerOpen(false)}
+              aria-label="Close navigation menu"
+              sx={{ color: "#ffffff" }}
+            >
+              <CloseIcon />
+            </IconButton>
+          </Box>
+
+          {/* Nav links list */}
+          <List disablePadding>
+            {navLinks.map((link) => (
+              <ListItemButton
+                key={link.href}
+                onClick={() => handleNavClick(link.href)}
+                sx={{
+                  borderRadius: "8px",
+                  mb: 0.5,
+                  "&:hover": {
+                    bgcolor: "rgba(255,255,255,0.1)",
+                  },
+                }}
+              >
+                <ListItemText
+                  primary={link.label}
+                  primaryTypographyProps={{
+                    sx: {
+                      color: "rgba(255,255,255,0.9)",
+                      fontWeight: 500,
+                      fontSize: 15,
+                    },
+                  }}
+                />
+              </ListItemButton>
+            ))}
+          </List>
+
+          {/* Mobile Sign In */}
+          <Box sx={{ mt: 3 }}>
+            <Button
+              variant="contained"
+              fullWidth
+              onClick={() => {
+                onSignIn?.();
+                setDrawerOpen(false);
+              }}
+              sx={{
+                bgcolor: "#2563eb",
+                color: "#ffffff",
+                fontWeight: 600,
+                fontSize: 14,
+                borderRadius: "8px",
+                height: 45,
+                textTransform: "none",
+                boxShadow: "none",
+                "&:hover": {
+                  bgcolor: "#1d4ed8",
+                  boxShadow: "none",
+                },
+              }}
+            >
+              Sign In
+            </Button>
+          </Box>
+        </Box>
+      </Drawer>
+    </>
+  );
+}

--- a/src/components/RootLayout.tsx
+++ b/src/components/RootLayout.tsx
@@ -1,9 +1,17 @@
 import { Box } from "@mui/material";
-import { Outlet } from "react-router";
+import { Outlet, useNavigate } from "react-router";
+import { AppHeader } from "./AppHeader";
 
 export function RootLayout() {
+  const navigate = useNavigate();
+
   return (
     <Box sx={{ minHeight: "100vh", bgcolor: "#f8fafc" }}>
+      <AppHeader
+        onNavLinkClick={(href) => navigate(href)}
+        onSignIn={() => navigate("/auth")}
+        onSearch={() => navigate("/browse")}
+      />
       <Outlet />
     </Box>
   );

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,3 +1,5 @@
+export { AppHeader } from './AppHeader';
+export type { AppHeaderProps, NavLink } from './AppHeader';
 export { CarCard } from './CarCard';
 export type { CarCardProps } from './CarCard';
 export { RootLayout } from './RootLayout';


### PR DESCRIPTION
## Summary

- Build responsive `AppHeader` component using MUI (`AppBar`, `Drawer`, `IconButton`, `Button`) matching the Figma design (node `13:247` in the Autocare file)
- Desktop: logo + nav links (Buy a Car, Sell Your Car, Browse, Financing) + search icon + Sign In button
- Mobile: logo + search icon + hamburger that opens a right-side `Drawer` with all nav links and Sign In
- Component is purely presentational — all interactions driven by callback props (`onNavLinkClick`, `onSignIn`, `onSearch`)
- Exported from `src/components/index.ts` (both component and `NavLink` type)
- `RootLayout` updated to render `AppHeader` with `useNavigate` callbacks
- Storybook stories: `Default`, `CustomNavLinks`, `Mobile`, `MobileWide`

Closes #8

🤖 Generated by UI Agent