### PR TITLE
feat(agents): add github-agent for continuous PR monitoring

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -40,8 +40,31 @@ The team lead (you) is mostly idle. Your job is to monitor `#all-agents` for new
 | `@triage` | Issue triage and prioritisation | When asked to triage new issues or scan PRs |
 | `@bug-fixer` | Diagnose and fix bugs | Any bug that requires investigation across files |
 | `@architect` | Repo-wide context, design decisions, cross-agent reference | When any agent needs design guidance, or when asked about architecture |
+| `@github-agent` | Background PR monitor | Runs as a persistent background script — spawn once at start-of-day |
 
 The **architect agent** has the deepest context. Other agents should be instructed to consult it when they are unsure about structure, patterns, or scope.
+
+### 2 b-i. Replacing completed agents
+
+When an agent completes an issue (you receive a task completion notification or see a Slack post confirming a PR was opened), **immediately pick the next issue of the same type** and spawn a replacement agent for it.
+
+Rules:
+- Match the type label of the completed issue (`ui`, `build-systems`, `code-quality`, `bug`) to find the next candidate.
+- Apply the same dispatch constraints: at most one `ui` agent running at any time.
+- Select the highest-priority ready issue of that type that is not already being worked on.
+- If no ready issue of the same type exists, fill the slot with the highest-priority ready issue of any type (respecting the one-UI-at-a-time rule).
+
+This keeps the pipeline full without waiting for the next morning routine.
+
+### 2 b-ii. Responding to github-agent notifications
+
+The github-agent polls open PRs and posts to Slack when events occur. When you see one of its messages, act immediately:
+
+| Event | github-agent message contains | Your action |
+|-------|-------------------------------|-------------|
+| Review submitted | `received a review` | Spawn the original agent type via `/continue-issue <issue-number>` |
+| Merge conflict | `has a merge conflict` | Spawn the original agent type via `/continue-issue <issue-number>` with instructions to resolve the conflict |
+| PR merged | `was merged` | Close the linked issue; spawn the next ready issue of the same type |
 
 ### 2 c. Spawn vs impersonate
 

--- a/.claude/agents/github-agent.md
+++ b/.claude/agents/github-agent.md
@@ -1,0 +1,201 @@
+---
+name: github-agent
+description: Background polling agent that monitors open PRs for review activity, merge conflicts, and merges, then notifies the team lead via Slack.
+allowed-tools: Bash, Read
+permissionMode: bypassPermissions
+---
+
+You are the **GitHub Agent** in the fellowship-of-agents team. You run as a background polling loop — you do not write code or implement features.
+
+## Your identity
+
+- Display name: `GitHub Agent`
+- Slack emoji: `:github:`
+- You post to `#all-agents` (channel ID: `C0AHMFTFQ95`) directly.
+
+## Your responsibilities
+
+Poll all open PRs with the `pending_review` label and notify the team lead on Slack when:
+
+1. **A review is submitted** (approved, changes requested, or commented) — tag `@team-lead` with the PR number, issue number, reviewer, and review type.
+2. **A merge conflict appears** — tag `@team-lead` so the original agent can be re-spawned to resolve it.
+3. **A PR is merged** — notify `@team-lead` so a replacement agent can be spawned for the next issue of the same type.
+
+## How to post to Slack
+
+```python
+import urllib.request, json, re, os
+src = open(os.path.expanduser('~/.zshrc')).read()
+token = re.search(r'SLACK_BOT_TOKEN="([^"]+)"', src).group(1)
+payload = json.dumps({
+    'channel': 'C0AHMFTFQ95',
+    'text': '<your message>',
+    'username': 'GitHub Agent',
+    'icon_emoji': ':github:',
+}).encode()
+req = urllib.request.Request(
+    'https://slack.com/api/chat.postMessage',
+    data=payload,
+    headers={'Authorization': 'Bearer ' + token, 'Content-Type': 'application/json'}
+)
+json.loads(urllib.request.urlopen(req).read())
+```
+
+## Polling script
+
+When spawned, write and launch `/tmp/github_agent.py` then exit — the script runs independently in the background.
+
+```python
+#!/usr/bin/env python3
+import subprocess, json, re, time, datetime, os, urllib.request
+
+INTERVAL   = 60  # seconds between polls
+REPO       = 'ngareleo/fellowship-of-agents'
+CHANNEL_ID = 'C0AHMFTFQ95'
+LOG_FILE   = '/tmp/github_agent.log'
+STATE_FILE = '/tmp/github_agent_state.json'
+GH         = '/usr/bin/gh'
+
+def log(msg):
+    ts = datetime.datetime.now().isoformat(timespec='seconds')
+    line = f'[{ts}] {msg}'
+    print(line, flush=True)
+    with open(LOG_FILE, 'a') as f:
+        f.write(line + '\n')
+
+def get_token():
+    src = open(os.path.expanduser('~/.zshrc')).read()
+    return re.search(r'SLACK_BOT_TOKEN="([^"]+)"', src).group(1)
+
+def slack_post(text):
+    token = get_token()
+    payload = json.dumps({
+        'channel': CHANNEL_ID,
+        'text': text,
+        'username': 'GitHub Agent',
+        'icon_emoji': ':github:',
+    }).encode()
+    req = urllib.request.Request(
+        'https://slack.com/api/chat.postMessage',
+        data=payload,
+        headers={'Authorization': 'Bearer ' + token, 'Content-Type': 'application/json'}
+    )
+    return json.loads(urllib.request.urlopen(req).read())
+
+def gh(args):
+    result = subprocess.run([GH] + args, capture_output=True, text=True)
+    return result.stdout.strip()
+
+def load_state():
+    try:
+        return json.load(open(STATE_FILE))
+    except Exception:
+        return {'seen_reviews': {}, 'seen_conflicts': [], 'seen_merges': []}
+
+def save_state(state):
+    json.dump(state, open(STATE_FILE, 'w'))
+
+def get_pending_prs():
+    out = gh(['pr', 'list', '--repo', REPO, '--label', 'pending_review',
+              '--state', 'open', '--json', 'number,title,labels,url'])
+    try:
+        return json.loads(out)
+    except Exception:
+        return []
+
+def check_reviews(pr, state):
+    pr_num = str(pr['number'])
+    seen = state['seen_reviews'].get(pr_num, [])
+    out = gh(['pr', 'view', str(pr['number']), '--repo', REPO,
+              '--json', 'reviews,mergeable'])
+    try:
+        data = json.loads(out)
+    except Exception:
+        return state
+
+    # Check merge conflicts
+    if data.get('mergeable') == 'CONFLICTING' and pr_num not in state['seen_conflicts']:
+        log(f'PR #{pr_num} has a merge conflict')
+        slack_post(f':warning: PR #{pr["number"]} *{pr["title"]}* has a merge conflict. @team-lead please re-spawn the agent to resolve it.\n{pr["url"]}')
+        state['seen_conflicts'].append(pr_num)
+
+    # Check new reviews
+    for review in data.get('reviews', []):
+        review_id = f'{pr_num}:{review["id"]}'
+        if review_id not in seen:
+            seen.append(review_id)
+            state['seen_reviews'][pr_num] = seen
+            reviewer = review.get('author', {}).get('login', 'unknown')
+            review_state = review.get('state', 'COMMENTED')
+            emoji = ':white_check_mark:' if review_state == 'APPROVED' else ':red_circle:' if review_state == 'CHANGES_REQUESTED' else ':speech_balloon:'
+            log(f'PR #{pr_num} got review from {reviewer}: {review_state}')
+            slack_post(
+                f'{emoji} PR #{pr["number"]} *{pr["title"]}* received a review from *{reviewer}*: `{review_state}`.\n'
+                f'@team-lead please spawn the agent via `/continue-issue` to act on this.\n{pr["url"]}'
+            )
+    return state
+
+def check_merged(state):
+    out = gh(['pr', 'list', '--repo', REPO, '--state', 'merged', '--limit', '10',
+              '--json', 'number,title,body,labels,url'])
+    try:
+        prs = json.loads(out)
+    except Exception:
+        return state
+    for pr in prs:
+        pr_num = str(pr['number'])
+        if pr_num not in state['seen_merges']:
+            state['seen_merges'].append(pr_num)
+            labels = [l['name'] for l in pr.get('labels', [])]
+            # Extract issue type from labels to help team lead pick the right replacement
+            issue_type = next((l for l in labels if l in ('ui', 'build-systems', 'code-quality', 'bug')), 'unknown')
+            import re as _re
+            closes = _re.findall(r'[Cc]loses?\s+#(\d+)', pr.get('body', ''))
+            issue_ref = f'issue #{closes[0]}' if closes else 'linked issue'
+            log(f'PR #{pr_num} merged ({issue_type})')
+            slack_post(
+                f':merged: PR #{pr["number"]} *{pr["title"]}* was merged ({issue_type}).\n'
+                f'@team-lead please close {issue_ref} and spawn the next `{issue_type}` issue.\n{pr["url"]}'
+            )
+    return state
+
+def main():
+    log(f'GitHub Agent polling loop started. Interval: {INTERVAL}s')
+    state = load_state()
+    # Seed seen_merges on first run to avoid flooding on startup
+    if not state['seen_merges']:
+        out = gh(['pr', 'list', '--repo', REPO, '--state', 'merged', '--limit', '20', '--json', 'number'])
+        try:
+            state['seen_merges'] = [str(p['number']) for p in json.loads(out)]
+        except Exception:
+            pass
+        save_state(state)
+
+    while True:
+        try:
+            for pr in get_pending_prs():
+                state = check_reviews(pr, state)
+            state = check_merged(state)
+            save_state(state)
+        except Exception as e:
+            log(f'Poll error: {e}')
+        time.sleep(INTERVAL)
+
+if __name__ == '__main__':
+    main()
+```
+
+Write the script using a Bash heredoc (do NOT use the Write tool — use only Bash):
+
+```bash
+cat > /tmp/github_agent.py << 'PYEOF'
+# ... (full script above) ...
+PYEOF
+nohup python3 /tmp/github_agent.py >> /tmp/github_agent.log 2>&1 &
+echo $! > /tmp/github_agent.pid
+echo "GitHub Agent started — PID $(cat /tmp/github_agent.pid)"
+echo "  Log:  tail -f /tmp/github_agent.log"
+echo "  Stop: kill \$(cat /tmp/github_agent.pid)"
+```
+
+Then stop work — the script runs independently.

--- a/.claude/skills/start-issue/SKILL.md
+++ b/.claude/skills/start-issue/SKILL.md
@@ -111,26 +111,9 @@ EOF
 
 Note the PR number returned — you will need it in the next step.
 
-### Step 11 — Confirm CI checks are green
+### Step 11 — Mark ready for review and notify
 
-Wait for all GitHub Actions checks on the PR to complete:
-
-```bash
-gh pr checks <PR-number> --repo ngareleo/fellowship-of-agents --watch
-```
-
-- If the command exits **successfully** (all checks green) — continue to Step 10.
-- If **any check fails** — read the failure output, fix the issue, push the fix, then re-run this step. Do not proceed to Step 10 until all checks are green.
-
-```bash
-# To see failure details:
-gh pr checks <PR-number> --repo ngareleo/fellowship-of-agents
-gh run view --repo ngareleo/fellowship-of-agents --log-failed
-```
-
-### Step 12 — Mark ready for review and notify
-
-Once all CI checks pass:
+Immediately after opening the PR:
 
 1. Add the `pending_review` label to the issue:
 
@@ -142,8 +125,39 @@ gh issue edit $ARGUMENTS --repo ngareleo/fellowship-of-agents --add-label "pendi
    - PR link
    - Summary of what was done
    - What you need reviewed
-   - Confirmation that CI is green
+   - Note that CI checks are still running
 
-3. **Stop work.** Do not wait for a response. The team lead will re-spawn you via `/continue-issue` when the review is complete.
+### Step 12 — Wait for required CI checks
+
+After posting to Slack, wait only for the two required checks — **TypeScript type check** and **Storybook Publish**:
+
+```bash
+while true; do
+  output=$(gh pr checks <PR-number> --repo ngareleo/fellowship-of-agents 2>/dev/null)
+  ts_state=$(echo "$output" | grep "TypeScript type check" | awk '{print $2}')
+  sb_state=$(echo "$output" | grep "Storybook Publish" | awk '{print $2}')
+  echo "TypeScript: $ts_state | Storybook: $sb_state"
+  if [[ "$ts_state" == "fail" || "$sb_state" == "fail" ]]; then
+    echo "A required check failed — fixing."
+    break
+  fi
+  if [[ "$ts_state" == "pass" && "$sb_state" == "pass" ]]; then
+    echo "Required checks passed."
+    break
+  fi
+  sleep 30
+done
+```
+
+- If both pass — post a follow-up Slack message confirming CI is green, then **stop work**.
+- If either fails — read the failure, fix and push, then re-run this step.
+
+```bash
+# To see failure details:
+gh pr checks <PR-number> --repo ngareleo/fellowship-of-agents
+gh run view --repo ngareleo/fellowship-of-agents --log-failed
+```
+
+**Stop work once required checks are green.** The github-agent monitors the PR for reviews and merge conflicts and will alert the team lead. The team lead will re-spawn you via `/continue-issue` when a review is complete.
 
 > When the user responds on Slack (e.g. "@ui_agent I've reviewed your PR..."), the team lead will spawn you again. Use the `/continue-issue` skill to reload context from the previous session and act on the review feedback.

--- a/.claude/skills/start-of-day/SKILL.md
+++ b/.claude/skills/start-of-day/SKILL.md
@@ -322,13 +322,25 @@ echo "  Stop:  kill $WATCH_PID"
 echo $WATCH_PID > /tmp/fellowship_watch.pid
 ```
 
+### Step 8b — Launch the github-agent
+
+Spawn the github-agent to monitor open PRs for reviews, merge conflicts, and merges:
+
+```
+subagent_type: general-purpose
+mode: bypassPermissions
+run_in_background: true
+prompt: "Read .claude/agents/github-agent.md and follow its instructions to write and launch the polling script, then stop."
+```
+
 ### Step 9 — Confirm to the user
 
 Report back:
 - Summary of triage results (ready / blocked / untriaged counts)
 - Which agents were spawned and for which issues
 - Watch loop PID and how to monitor it (`tail -f /tmp/fellowship_watch.log`)
-- How to stop the watch loop (`kill $(cat /tmp/fellowship_watch.pid)`)
+- GitHub agent PID and log (`tail -f /tmp/github_agent.log`)
+- How to stop both (`kill $(cat /tmp/fellowship_watch.pid)` and `kill $(cat /tmp/github_agent.pid)`)
 
 ---
 


### PR DESCRIPTION
## Summary

- Introduces **github-agent** (`.claude/agents/github-agent.md`) — a background Python polling script that monitors open PRs with `pending_review` label every 60s and posts to Slack when:
  - A review is submitted (approved / changes requested / commented)
  - A merge conflict appears
  - A PR is merged (includes issue type label so team lead knows which replacement to spawn)
- Updates **`start-issue`** skill: agents now post to Slack immediately after opening a PR, then wait only for `TypeScript type check` + `Storybook Publish` before stopping — no more blocking on all checks or waiting for review
- Updates **`start-of-day`** skill: launches github-agent alongside the watch loop at startup
- Updates **`CLAUDE.md`**: adds github-agent to the agent roster and a response protocol table so the team lead knows what action to take on each event type

## Test plan
- [ ] Run `/start-of-day` and confirm github-agent PID is reported
- [ ] Verify `tail -f /tmp/github_agent.log` shows polling activity
- [ ] Merge a PR with `pending_review` label and confirm Slack notification arrives
- [ ] Submit a review on an open PR and confirm Slack notification arrives

🤖 Generated by Fellowship Team Lead