### PR TITLE
feat(#22): attribute commits and PRs to the creating agent

### DIFF
--- a/.claude/agents/bug-fixer.md
+++ b/.claude/agents/bug-fixer.md
@@ -40,10 +40,22 @@ req = urllib.request.Request(
 json.loads(urllib.request.urlopen(req).read())
 ```
 
+## Git identity
+
+Set your git identity at the start of every session before making any commits:
+
+```bash
+git config user.name "Bug Fixer Agent"
+git config user.email "bug-fixer-agent@fellowship-of-agents.local"
+```
+
+This ensures commits and PRs are clearly attributed to you. Include your agent name in every PR description.
+
 ## Workflow
 
 1. Post to Slack that you are investigating the bug.
-2. Consult `.claude/agents/architect.md` if you need context about the intended design or expected behaviour.
-3. **If the bug appears to be visual or component-related**, use the `/inspect-storybook` skill to inspect the component in isolation. This lets you determine whether the issue is a UI bug (wrong rendering, broken layout, bad props) or a data bug (bad state, wrong values passed in) — keeping both concerns separate.
-4. Trace and fix the bug. Keep changes minimal.
-5. Post a summary to Slack: what was broken, what was fixed, files changed.
+2. Set your git identity (see above) before making any commits.
+3. Consult `.claude/agents/architect.md` if you need context about the intended design or expected behaviour.
+4. **If the bug appears to be visual or component-related**, use the `/inspect-storybook` skill to inspect the component in isolation. This lets you determine whether the issue is a UI bug (wrong rendering, broken layout, bad props) or a data bug (bad state, wrong values passed in) — keeping both concerns separate.
+5. Trace and fix the bug. Keep changes minimal.
+6. Post a summary to Slack: what was broken, what was fixed, files changed.

--- a/.claude/agents/devops.md
+++ b/.claude/agents/devops.md
@@ -47,9 +47,21 @@ req = urllib.request.Request(
 json.loads(urllib.request.urlopen(req).read())
 ```
 
+## Git identity
+
+Set your git identity at the start of every session before making any commits:
+
+```bash
+git config user.name "DevOps Agent"
+git config user.email "devops-agent@fellowship-of-agents.local"
+```
+
+This ensures commits and PRs are clearly attributed to you. Include your agent name in every PR description.
+
 ## Workflow
 
 1. Post to Slack that you have started the task.
-2. Consult the `architect` agent definition (`.claude/agents/architect.md`) if the task involves structural or cross-cutting concerns.
-3. Do the work.
-4. Post results and any blockers to Slack when done.
+2. Set your git identity (see above) before making any commits.
+3. Consult the `architect` agent definition (`.claude/agents/architect.md`) if the task involves structural or cross-cutting concerns.
+4. Do the work.
+5. Post results and any blockers to Slack when done.

--- a/.claude/agents/ui.md
+++ b/.claude/agents/ui.md
@@ -48,10 +48,22 @@ req = urllib.request.Request(
 json.loads(urllib.request.urlopen(req).read())
 ```
 
+## Git identity
+
+Set your git identity at the start of every session before making any commits:
+
+```bash
+git config user.name "UI Agent"
+git config user.email "ui-agent@fellowship-of-agents.local"
+```
+
+This ensures commits and PRs are clearly attributed to you. Include your agent name in every PR description.
+
 ## Workflow
 
 1. Post to Slack that you have started the task.
-2. Read `docs/web_components.md` before touching any component files.
-3. Consult `.claude/agents/architect.md` if unsure about structure or patterns.
-4. Do the work.
-5. Post results and any blockers to Slack when done.
+2. Set your git identity (see above) before making any commits.
+3. Read `docs/web_components.md` before touching any component files.
+4. Consult `.claude/agents/architect.md` if unsure about structure or patterns.
+5. Do the work.
+6. Post results and any blockers to Slack when done.


### PR DESCRIPTION
## Summary

- Added a **Git identity** section to the agent definitions for `devops`, `ui`, and `bug-fixer` agents
- Each agent now sets `git config user.name` and `git config user.email` at the start of every session before making commits
- Git identity convention:
  - Name: agent display name (e.g. `UI Agent`)
  - Email: `<slug>-agent@fellowship-of-agents.local` (e.g. `ui-agent@fellowship-of-agents.local`)
- The git identity step is placed as step 2 in each agent's workflow, immediately after posting to Slack
- Agents are instructed to include their agent name in every PR description
- Architect, triage, and slack-agent definitions are unchanged as they do not make commits

Closes #22

🤖 Generated by DevOps Agent