### PR TITLE
feat(auth): build authentication page + Storybook stories

### DIFF
--- a/src/components/AuthHeroPanel.mdx
+++ b/src/components/AuthHeroPanel.mdx
@@ -1,0 +1,43 @@
+{/* src/components/AuthHeroPanel.mdx */}
+
+import { Meta, Canvas, Controls } from "@storybook/addon-docs/blocks";
+import * as AuthHeroPanelStories from "./AuthHeroPanel.stories";
+
+<Meta of={AuthHeroPanelStories} />
+
+# AuthHeroPanel
+
+The left-side decorative panel on the authentication page. It displays a large car emoji, a
+heading, and a subtext description on a dark gradient background. The panel is hidden on mobile
+viewports (`xs`) and visible from the `md` breakpoint upward.
+
+## Usage
+
+<Canvas of={AuthHeroPanelStories.Default} />
+<Controls of={AuthHeroPanelStories.Default} />
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `heading` | `string` | `"Find Your Perfect Car"` | Heading text shown on the hero panel. |
+| `subtext` | `string` | `"Join thousands of happy customers…"` | Subtext shown below the heading. |
+
+## Variants
+
+### Custom copy
+
+<Canvas of={AuthHeroPanelStories.CustomCopy} />
+
+Use the `heading` and `subtext` props to adapt the panel copy for different campaigns or
+onboarding flows without changing the visual treatment.
+
+## Design notes
+
+- The gradient runs from `palette.custom.navbarBg` to `palette.custom.heroPanelGradientEnd` at
+  139.7 degrees, matching the Figma design node `8-2111`.
+- The panel occupies `flex: 1` of the split-screen layout alongside the form panel.
+- The car emoji is rendered as a `Typography` element (font size 120) so it inherits the system
+  emoji font and scales correctly across platforms.
+- Hidden on mobile via `display: { xs: "none", md: "flex" }` — the form panel takes the full
+  width on small screens.

--- a/src/components/AuthHeroPanel.stories.tsx
+++ b/src/components/AuthHeroPanel.stories.tsx
@@ -1,0 +1,31 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { AuthHeroPanel } from "./AuthHeroPanel";
+import { withTheme } from "~/storybooks";
+
+const meta: Meta<typeof AuthHeroPanel> = {
+  title: "Components/AuthHeroPanel",
+  component: AuthHeroPanel,
+  decorators: [withTheme],
+  parameters: {
+    layout: "fullscreen",
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof AuthHeroPanel>;
+
+/**
+ * Default hero panel with standard AutoExchange copy.
+ */
+export const Default: Story = {};
+
+/**
+ * Custom heading and subtext.
+ */
+export const CustomCopy: Story = {
+  args: {
+    heading: "Your Next Car Awaits",
+    subtext: "Browse thousands of verified listings from trusted sellers across the country.",
+  },
+};

--- a/src/components/AuthHeroPanel.tsx
+++ b/src/components/AuthHeroPanel.tsx
@@ -23,7 +23,8 @@ export function AuthHeroPanel({
         flexDirection: "column",
         alignItems: "center",
         justifyContent: "center",
-        background: "linear-gradient(139.7deg, #0f172a 14.645%, #334155 85.355%)",
+        background: (t) =>
+          `linear-gradient(139.7deg, ${t.palette.custom.navbarBg} 14.645%, ${t.palette.custom.heroPanelGradientEnd} 85.355%)`,
         minHeight: "100vh",
         px: 6,
         textAlign: "center",
@@ -37,7 +38,7 @@ export function AuthHeroPanel({
           fontFamily: "'Barlow', sans-serif",
           fontSize: 40,
           lineHeight: "48px",
-          color: "#ffffff",
+          color: (t) => t.palette.primary.contrastText,
           mb: 2,
         }}
       >
@@ -47,7 +48,7 @@ export function AuthHeroPanel({
         sx={{
           fontSize: 18,
           lineHeight: "27px",
-          color: "#cbd5e1",
+          color: (t) => t.palette.custom.checkboxUnchecked,
           maxWidth: 400,
         }}
       >

--- a/src/components/AuthHeroPanel.tsx
+++ b/src/components/AuthHeroPanel.tsx
@@ -1,0 +1,58 @@
+import { Box, Typography } from "@mui/material";
+
+export type AuthHeroPanelProps = {
+  /** Heading text shown on the hero panel. */
+  heading?: string;
+  /** Subtext shown below the heading. */
+  subtext?: string;
+};
+
+/**
+ * Left-side hero panel on the authentication page.
+ * Dark gradient background with an emoji car, tagline, and description.
+ */
+export function AuthHeroPanel({
+  heading = "Find Your Perfect Car",
+  subtext = "Join thousands of happy customers who found their dream car on AutoExchange.",
+}: AuthHeroPanelProps) {
+  return (
+    <Box
+      sx={{
+        flex: 1,
+        display: { xs: "none", md: "flex" },
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "center",
+        background: "linear-gradient(139.7deg, #0f172a 14.645%, #334155 85.355%)",
+        minHeight: "100vh",
+        px: 6,
+        textAlign: "center",
+      }}
+    >
+      <Typography sx={{ fontSize: 120, lineHeight: 1.2, mb: 3 }}>
+        {"🚗"}
+      </Typography>
+      <Typography
+        sx={{
+          fontFamily: "'Barlow', sans-serif",
+          fontSize: 40,
+          lineHeight: "48px",
+          color: "#ffffff",
+          mb: 2,
+        }}
+      >
+        {heading}
+      </Typography>
+      <Typography
+        sx={{
+          fontSize: 18,
+          lineHeight: "27px",
+          color: "#cbd5e1",
+          maxWidth: 400,
+        }}
+      >
+        {subtext}
+      </Typography>
+    </Box>
+  );
+}

--- a/src/components/SignInForm.mdx
+++ b/src/components/SignInForm.mdx
@@ -1,0 +1,86 @@
+{/* src/components/SignInForm.mdx */}
+
+import { Meta, Canvas, Controls } from "@storybook/addon-docs/blocks";
+import * as SignInFormStories from "./SignInForm.stories";
+
+<Meta of={SignInFormStories} />
+
+# SignInForm
+
+A controlled sign-in form with email, password (with show/hide toggle), a remember-me checkbox,
+a forgot-password link, a primary submit button, and social sign-in buttons for Google and
+Facebook.
+
+The component manages its own field state internally. Validation errors and loading state are
+passed in as props so the parent controls authentication logic.
+
+## Usage
+
+<Canvas of={SignInFormStories.Default} />
+<Controls of={SignInFormStories.Default} />
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `onSubmit` | `(values: SignInFormValues) => void` | — | Called when the user submits the form. Receives `{ email, password, rememberMe }`. |
+| `onForgotPassword` | `() => void` | — | Called when the user clicks the "Forgot password?" link. |
+| `onGoogleSignIn` | `() => void` | — | Called when the user clicks the Google social button. |
+| `onFacebookSignIn` | `() => void` | — | Called when the user clicks the Facebook social button. |
+| `errors` | `SignInFormError` | — | Validation errors to display. Keys: `email`, `password`, `general`. |
+| `loading` | `boolean` | `false` | When `true`, the submit button is disabled and shows "Signing in…". |
+
+### SignInFormValues type
+
+```ts
+type SignInFormValues = {
+  email: string;
+  password: string;
+  rememberMe: boolean;
+};
+```
+
+### SignInFormError type
+
+```ts
+type SignInFormError = {
+  email?: string;
+  password?: string;
+  general?: string;
+};
+```
+
+## Variants
+
+### With field errors
+
+<Canvas of={SignInFormStories.WithErrors} />
+
+Field-level errors appear as helper text below the relevant input. Use this state after client-side
+validation or when the server returns field-specific error messages.
+
+### General error
+
+<Canvas of={SignInFormStories.GeneralError} />
+
+A `general` error renders as a styled banner above the fields. Use it for errors that are not
+tied to a specific field, such as incorrect credentials.
+
+### Loading
+
+<Canvas of={SignInFormStories.Loading} />
+
+Pass `loading={true}` while the sign-in request is in flight. The submit button is disabled and
+its label changes to "Signing in…".
+
+## Design notes
+
+- The form uses `noValidate` to disable native browser validation and rely on the `errors` prop
+  for a consistent cross-browser experience.
+- The password visibility toggle uses MUI `IconButton` inside an `InputAdornment` for full
+  keyboard and screen-reader accessibility (`aria-label` switches between "Show password" and
+  "Hide password").
+- All colour values come from the MUI theme (`palette.custom.*` and `palette.primary.*`) — no
+  hardcoded hex values.
+- The social buttons are placeholders — wire up `onGoogleSignIn` / `onFacebookSignIn` to your
+  OAuth flow.

--- a/src/components/SignInForm.stories.tsx
+++ b/src/components/SignInForm.stories.tsx
@@ -1,0 +1,65 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { SignInForm } from "./SignInForm";
+import { withTheme } from "~/storybooks";
+import { Box } from "@mui/material";
+
+const meta: Meta<typeof SignInForm> = {
+  title: "Components/SignInForm",
+  component: SignInForm,
+  decorators: [
+    withTheme,
+    (Story) => (
+      <Box sx={{ maxWidth: 420, mx: "auto", p: 4 }}>
+        <Story />
+      </Box>
+    ),
+  ],
+  argTypes: {
+    loading: { control: "boolean" },
+    onSubmit: { action: "onSubmit" },
+    onForgotPassword: { action: "onForgotPassword" },
+    onGoogleSignIn: { action: "onGoogleSignIn" },
+    onFacebookSignIn: { action: "onFacebookSignIn" },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof SignInForm>;
+
+/**
+ * Default empty sign-in form.
+ */
+export const Default: Story = {};
+
+/**
+ * Form with validation errors shown — e.g. after a failed submission.
+ */
+export const WithErrors: Story = {
+  args: {
+    errors: {
+      email: "Please enter a valid email address.",
+      password: "Password must be at least 8 characters.",
+    },
+  },
+};
+
+/**
+ * General / server-level error (e.g. wrong credentials).
+ */
+export const GeneralError: Story = {
+  args: {
+    errors: {
+      general: "The email or password you entered is incorrect. Please try again.",
+    },
+  },
+};
+
+/**
+ * Loading state — shown while sign-in request is in flight.
+ */
+export const Loading: Story = {
+  args: {
+    loading: true,
+  },
+};

--- a/src/components/SignInForm.tsx
+++ b/src/components/SignInForm.tsx
@@ -1,0 +1,304 @@
+import {
+  Box,
+  Button,
+  Checkbox,
+  FormControlLabel,
+  IconButton,
+  InputAdornment,
+  Stack,
+  TextField,
+  Typography,
+} from "@mui/material";
+import VisibilityIcon from "@mui/icons-material/Visibility";
+import VisibilityOffIcon from "@mui/icons-material/VisibilityOff";
+import { useState } from "react";
+
+export type SignInFormValues = {
+  email: string;
+  password: string;
+  rememberMe: boolean;
+};
+
+export type SignInFormError = {
+  email?: string;
+  password?: string;
+  general?: string;
+};
+
+export type SignInFormProps = {
+  /** Called when the user submits valid credentials. */
+  onSubmit?: (values: SignInFormValues) => void;
+  /** Called when the user clicks "Forgot password?". */
+  onForgotPassword?: () => void;
+  /** Called when the user clicks the Google social button. */
+  onGoogleSignIn?: () => void;
+  /** Called when the user clicks the Facebook social button. */
+  onFacebookSignIn?: () => void;
+  /** Validation errors to display. */
+  errors?: SignInFormError;
+  /** When true the submit button shows a loading state. */
+  loading?: boolean;
+};
+
+/**
+ * Sign-in form with email, password (show/hide toggle), remember me checkbox,
+ * forgot password link, and social sign-in buttons.
+ */
+export function SignInForm({
+  onSubmit,
+  onForgotPassword,
+  onGoogleSignIn,
+  onFacebookSignIn,
+  errors,
+  loading = false,
+}: SignInFormProps) {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [rememberMe, setRememberMe] = useState(false);
+  const [showPassword, setShowPassword] = useState(false);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    onSubmit?.({ email, password, rememberMe });
+  };
+
+  return (
+    <Box component="form" onSubmit={handleSubmit} noValidate>
+      <Stack spacing={3}>
+        {/* General error */}
+        {errors?.general && (
+          <Typography
+            sx={{
+              fontSize: 14,
+              color: "#ef4444",
+              bgcolor: "#fef2f2",
+              border: "1px solid #fecaca",
+              borderRadius: "8px",
+              px: 2,
+              py: 1.5,
+            }}
+          >
+            {errors.general}
+          </Typography>
+        )}
+
+        {/* Email field */}
+        <Box>
+          <Typography
+            component="label"
+            htmlFor="signin-email"
+            sx={{
+              display: "block",
+              fontSize: 14,
+              fontWeight: 500,
+              color: "#334155",
+              mb: 0.75,
+            }}
+          >
+            Email Address
+          </Typography>
+          <TextField
+            id="signin-email"
+            type="email"
+            placeholder="Enter your email"
+            fullWidth
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            error={Boolean(errors?.email)}
+            helperText={errors?.email}
+            inputProps={{ "aria-label": "Email Address" }}
+            sx={{
+              "& .MuiOutlinedInput-root": {
+                borderRadius: "8px",
+                height: 53,
+                "& fieldset": { borderColor: "#e2e8f0", borderWidth: 2 },
+                "&:hover fieldset": { borderColor: "#94a3b8" },
+                "&.Mui-focused fieldset": { borderColor: "#2563eb" },
+              },
+              "& input": { fontSize: 14, color: "#0f172a" },
+              "& input::placeholder": { color: "#94a3b8" },
+            }}
+          />
+        </Box>
+
+        {/* Password field */}
+        <Box>
+          <Typography
+            component="label"
+            htmlFor="signin-password"
+            sx={{
+              display: "block",
+              fontSize: 14,
+              fontWeight: 500,
+              color: "#334155",
+              mb: 0.75,
+            }}
+          >
+            Password
+          </Typography>
+          <TextField
+            id="signin-password"
+            type={showPassword ? "text" : "password"}
+            placeholder="Enter your password"
+            fullWidth
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            error={Boolean(errors?.password)}
+            helperText={errors?.password}
+            InputProps={{
+              endAdornment: (
+                <InputAdornment position="end">
+                  <IconButton
+                    aria-label={showPassword ? "Hide password" : "Show password"}
+                    onClick={() => setShowPassword((prev) => !prev)}
+                    edge="end"
+                    size="small"
+                    sx={{ color: "#94a3b8" }}
+                  >
+                    {showPassword ? (
+                      <VisibilityOffIcon sx={{ fontSize: 20 }} />
+                    ) : (
+                      <VisibilityIcon sx={{ fontSize: 20 }} />
+                    )}
+                  </IconButton>
+                </InputAdornment>
+              ),
+            }}
+            sx={{
+              "& .MuiOutlinedInput-root": {
+                borderRadius: "8px",
+                height: 53,
+                "& fieldset": { borderColor: "#e2e8f0", borderWidth: 2 },
+                "&:hover fieldset": { borderColor: "#94a3b8" },
+                "&.Mui-focused fieldset": { borderColor: "#2563eb" },
+              },
+              "& input": { fontSize: 14, color: "#0f172a" },
+              "& input::placeholder": { color: "#94a3b8" },
+            }}
+          />
+        </Box>
+
+        {/* Remember me + Forgot password */}
+        <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+          <FormControlLabel
+            control={
+              <Checkbox
+                checked={rememberMe}
+                onChange={(e) => setRememberMe(e.target.checked)}
+                size="small"
+                sx={{
+                  color: "#cbd5e1",
+                  "&.Mui-checked": { color: "#2563eb" },
+                  borderRadius: "4px",
+                }}
+              />
+            }
+            label={
+              <Typography sx={{ fontSize: 14, color: "#475569" }}>
+                Remember me
+              </Typography>
+            }
+          />
+          <Typography
+            component="button"
+            type="button"
+            onClick={onForgotPassword}
+            sx={{
+              fontSize: 14,
+              fontWeight: 500,
+              color: "#2563eb",
+              background: "none",
+              border: "none",
+              cursor: "pointer",
+              p: 0,
+              "&:hover": { textDecoration: "underline" },
+            }}
+          >
+            Forgot password?
+          </Typography>
+        </Box>
+
+        {/* Submit button */}
+        <Button
+          type="submit"
+          variant="contained"
+          fullWidth
+          disabled={loading}
+          sx={{
+            bgcolor: "#2563eb",
+            color: "#ffffff",
+            fontWeight: 600,
+            fontSize: 14,
+            borderRadius: "8px",
+            height: 49,
+            textTransform: "none",
+            boxShadow: "none",
+            "&:hover": { bgcolor: "#1d4ed8", boxShadow: "none" },
+            "&:disabled": { bgcolor: "#93c5fd" },
+          }}
+        >
+          {loading ? "Signing in…" : "Sign In"}
+        </Button>
+
+        {/* Divider */}
+        <Box sx={{ display: "flex", alignItems: "center", gap: 2 }}>
+          <Box sx={{ flex: 1, height: 1, bgcolor: "#e2e8f0" }} />
+          <Typography sx={{ fontSize: 13, color: "#64748b", whiteSpace: "nowrap" }}>
+            or continue with
+          </Typography>
+          <Box sx={{ flex: 1, height: 1, bgcolor: "#e2e8f0" }} />
+        </Box>
+
+        {/* Social buttons */}
+        <Stack direction="row" spacing={1.5}>
+          <Button
+            variant="outlined"
+            fullWidth
+            onClick={onGoogleSignIn}
+            startIcon={
+              <Typography component="span" sx={{ fontSize: 16, lineHeight: 1 }}>
+                G
+              </Typography>
+            }
+            sx={{
+              height: 49,
+              borderColor: "#e2e8f0",
+              borderWidth: 2,
+              borderRadius: "8px",
+              color: "#334155",
+              fontWeight: 500,
+              fontSize: 14,
+              textTransform: "none",
+              "&:hover": { borderColor: "#94a3b8", bgcolor: "#f8fafc", borderWidth: 2 },
+            }}
+          >
+            Google
+          </Button>
+          <Button
+            variant="outlined"
+            fullWidth
+            onClick={onFacebookSignIn}
+            startIcon={
+              <Typography component="span" sx={{ fontSize: 16, lineHeight: 1 }}>
+                f
+              </Typography>
+            }
+            sx={{
+              height: 49,
+              borderColor: "#e2e8f0",
+              borderWidth: 2,
+              borderRadius: "8px",
+              color: "#334155",
+              fontWeight: 500,
+              fontSize: 14,
+              textTransform: "none",
+              "&:hover": { borderColor: "#94a3b8", bgcolor: "#f8fafc", borderWidth: 2 },
+            }}
+          >
+            Facebook
+          </Button>
+        </Stack>
+      </Stack>
+    </Box>
+  );
+}

--- a/src/components/SignInForm.tsx
+++ b/src/components/SignInForm.tsx
@@ -62,6 +62,35 @@ export function SignInForm({
     onSubmit?.({ email, password, rememberMe });
   };
 
+  const fieldSx = {
+    "& .MuiOutlinedInput-root": {
+      borderRadius: "8px",
+      height: 53,
+      "& fieldset": {
+        borderColor: (t: import("@mui/material/styles").Theme) =>
+          t.palette.custom.divider,
+        borderWidth: 2,
+      },
+      "&:hover fieldset": {
+        borderColor: (t: import("@mui/material/styles").Theme) =>
+          t.palette.custom.cardImagePlaceholder,
+      },
+      "&.Mui-focused fieldset": {
+        borderColor: (t: import("@mui/material/styles").Theme) =>
+          t.palette.primary.main,
+      },
+    },
+    "& input": {
+      fontSize: 14,
+      color: (t: import("@mui/material/styles").Theme) =>
+        t.palette.text.primary,
+    },
+    "& input::placeholder": {
+      color: (t: import("@mui/material/styles").Theme) =>
+        t.palette.custom.cardImagePlaceholder,
+    },
+  };
+
   return (
     <Box component="form" onSubmit={handleSubmit} noValidate>
       <Stack spacing={3}>
@@ -70,9 +99,9 @@ export function SignInForm({
           <Typography
             sx={{
               fontSize: 14,
-              color: "#ef4444",
-              bgcolor: "#fef2f2",
-              border: "1px solid #fecaca",
+              color: (t) => t.palette.custom.errorText,
+              bgcolor: (t) => t.palette.custom.errorBg,
+              border: (t) => `1px solid ${t.palette.custom.errorBorder}`,
               borderRadius: "8px",
               px: 2,
               py: 1.5,
@@ -91,7 +120,7 @@ export function SignInForm({
               display: "block",
               fontSize: 14,
               fontWeight: 500,
-              color: "#334155",
+              color: (t) => t.palette.custom.labelText,
               mb: 0.75,
             }}
           >
@@ -107,17 +136,7 @@ export function SignInForm({
             error={Boolean(errors?.email)}
             helperText={errors?.email}
             inputProps={{ "aria-label": "Email Address" }}
-            sx={{
-              "& .MuiOutlinedInput-root": {
-                borderRadius: "8px",
-                height: 53,
-                "& fieldset": { borderColor: "#e2e8f0", borderWidth: 2 },
-                "&:hover fieldset": { borderColor: "#94a3b8" },
-                "&.Mui-focused fieldset": { borderColor: "#2563eb" },
-              },
-              "& input": { fontSize: 14, color: "#0f172a" },
-              "& input::placeholder": { color: "#94a3b8" },
-            }}
+            sx={fieldSx}
           />
         </Box>
 
@@ -130,7 +149,7 @@ export function SignInForm({
               display: "block",
               fontSize: 14,
               fontWeight: 500,
-              color: "#334155",
+              color: (t) => t.palette.custom.labelText,
               mb: 0.75,
             }}
           >
@@ -153,7 +172,7 @@ export function SignInForm({
                     onClick={() => setShowPassword((prev) => !prev)}
                     edge="end"
                     size="small"
-                    sx={{ color: "#94a3b8" }}
+                    sx={{ color: (t) => t.palette.custom.cardImagePlaceholder }}
                   >
                     {showPassword ? (
                       <VisibilityOffIcon sx={{ fontSize: 20 }} />
@@ -164,17 +183,7 @@ export function SignInForm({
                 </InputAdornment>
               ),
             }}
-            sx={{
-              "& .MuiOutlinedInput-root": {
-                borderRadius: "8px",
-                height: 53,
-                "& fieldset": { borderColor: "#e2e8f0", borderWidth: 2 },
-                "&:hover fieldset": { borderColor: "#94a3b8" },
-                "&.Mui-focused fieldset": { borderColor: "#2563eb" },
-              },
-              "& input": { fontSize: 14, color: "#0f172a" },
-              "& input::placeholder": { color: "#94a3b8" },
-            }}
+            sx={fieldSx}
           />
         </Box>
 
@@ -187,14 +196,14 @@ export function SignInForm({
                 onChange={(e) => setRememberMe(e.target.checked)}
                 size="small"
                 sx={{
-                  color: "#cbd5e1",
-                  "&.Mui-checked": { color: "#2563eb" },
+                  color: (t) => t.palette.custom.checkboxUnchecked,
+                  "&.Mui-checked": { color: (t) => t.palette.primary.main },
                   borderRadius: "4px",
                 }}
               />
             }
             label={
-              <Typography sx={{ fontSize: 14, color: "#475569" }}>
+              <Typography sx={{ fontSize: 14, color: (t) => t.palette.text.secondary }}>
                 Remember me
               </Typography>
             }
@@ -206,7 +215,7 @@ export function SignInForm({
             sx={{
               fontSize: 14,
               fontWeight: 500,
-              color: "#2563eb",
+              color: (t) => t.palette.primary.main,
               background: "none",
               border: "none",
               cursor: "pointer",
@@ -225,16 +234,16 @@ export function SignInForm({
           fullWidth
           disabled={loading}
           sx={{
-            bgcolor: "#2563eb",
-            color: "#ffffff",
+            bgcolor: (t) => t.palette.primary.main,
+            color: (t) => t.palette.primary.contrastText,
             fontWeight: 600,
             fontSize: 14,
             borderRadius: "8px",
             height: 49,
             textTransform: "none",
             boxShadow: "none",
-            "&:hover": { bgcolor: "#1d4ed8", boxShadow: "none" },
-            "&:disabled": { bgcolor: "#93c5fd" },
+            "&:hover": { bgcolor: (t) => t.palette.primary.dark, boxShadow: "none" },
+            "&:disabled": { bgcolor: (t) => t.palette.custom.primaryDisabled },
           }}
         >
           {loading ? "Signing in…" : "Sign In"}
@@ -242,11 +251,11 @@ export function SignInForm({
 
         {/* Divider */}
         <Box sx={{ display: "flex", alignItems: "center", gap: 2 }}>
-          <Box sx={{ flex: 1, height: 1, bgcolor: "#e2e8f0" }} />
-          <Typography sx={{ fontSize: 13, color: "#64748b", whiteSpace: "nowrap" }}>
+          <Box sx={{ flex: 1, height: 1, bgcolor: (t) => t.palette.custom.divider }} />
+          <Typography sx={{ fontSize: 13, color: (t) => t.palette.text.secondary, whiteSpace: "nowrap" }}>
             or continue with
           </Typography>
-          <Box sx={{ flex: 1, height: 1, bgcolor: "#e2e8f0" }} />
+          <Box sx={{ flex: 1, height: 1, bgcolor: (t) => t.palette.custom.divider }} />
         </Box>
 
         {/* Social buttons */}
@@ -262,14 +271,18 @@ export function SignInForm({
             }
             sx={{
               height: 49,
-              borderColor: "#e2e8f0",
+              borderColor: (t) => t.palette.custom.divider,
               borderWidth: 2,
               borderRadius: "8px",
-              color: "#334155",
+              color: (t) => t.palette.custom.labelText,
               fontWeight: 500,
               fontSize: 14,
               textTransform: "none",
-              "&:hover": { borderColor: "#94a3b8", bgcolor: "#f8fafc", borderWidth: 2 },
+              "&:hover": {
+                borderColor: (t) => t.palette.custom.cardImagePlaceholder,
+                bgcolor: (t) => t.palette.background.default,
+                borderWidth: 2,
+              },
             }}
           >
             Google
@@ -285,14 +298,18 @@ export function SignInForm({
             }
             sx={{
               height: 49,
-              borderColor: "#e2e8f0",
+              borderColor: (t) => t.palette.custom.divider,
               borderWidth: 2,
               borderRadius: "8px",
-              color: "#334155",
+              color: (t) => t.palette.custom.labelText,
               fontWeight: 500,
               fontSize: 14,
               textTransform: "none",
-              "&:hover": { borderColor: "#94a3b8", bgcolor: "#f8fafc", borderWidth: 2 },
+              "&:hover": {
+                borderColor: (t) => t.palette.custom.cardImagePlaceholder,
+                bgcolor: (t) => t.palette.background.default,
+                borderWidth: 2,
+              },
             }}
           >
             Facebook

--- a/src/components/SignUpForm.mdx
+++ b/src/components/SignUpForm.mdx
@@ -1,0 +1,86 @@
+{/* src/components/SignUpForm.mdx */}
+
+import { Meta, Canvas, Controls } from "@storybook/addon-docs/blocks";
+import * as SignUpFormStories from "./SignUpForm.stories";
+
+<Meta of={SignUpFormStories} />
+
+# SignUpForm
+
+A controlled registration form with full name, email, password, and confirm-password fields (the
+two password fields each have an independent show/hide toggle). Social sign-up buttons for Google
+and Facebook are shown below the primary submit button.
+
+The component manages its own field state internally. Validation errors and loading state are
+passed in as props so the parent controls registration logic.
+
+## Usage
+
+<Canvas of={SignUpFormStories.Default} />
+<Controls of={SignUpFormStories.Default} />
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `onSubmit` | `(values: SignUpFormValues) => void` | — | Called when the user submits the form. Receives `{ fullName, email, password, confirmPassword }`. |
+| `onGoogleSignUp` | `() => void` | — | Called when the user clicks the Google social button. |
+| `onFacebookSignUp` | `() => void` | — | Called when the user clicks the Facebook social button. |
+| `errors` | `SignUpFormError` | — | Validation errors to display. Keys: `fullName`, `email`, `password`, `confirmPassword`, `general`. |
+| `loading` | `boolean` | `false` | When `true`, the submit button is disabled and shows "Creating account…". |
+
+### SignUpFormValues type
+
+```ts
+type SignUpFormValues = {
+  fullName: string;
+  email: string;
+  password: string;
+  confirmPassword: string;
+};
+```
+
+### SignUpFormError type
+
+```ts
+type SignUpFormError = {
+  fullName?: string;
+  email?: string;
+  password?: string;
+  confirmPassword?: string;
+  general?: string;
+};
+```
+
+## Variants
+
+### With field errors
+
+<Canvas of={SignUpFormStories.WithErrors} />
+
+Field-level errors appear as helper text beneath each invalid input. All four fields can carry
+independent error messages simultaneously.
+
+### General error
+
+<Canvas of={SignUpFormStories.GeneralError} />
+
+A `general` error renders as a styled banner above the fields. Use it for errors not tied to a
+specific field, such as "email already registered".
+
+### Loading
+
+<Canvas of={SignUpFormStories.Loading} />
+
+Pass `loading={true}` while the account-creation request is in flight. The submit button is
+disabled and its label changes to "Creating account…".
+
+## Design notes
+
+- The password and confirm-password fields each have an independent `showPassword` / `showConfirm`
+  state so the user can reveal one without affecting the other.
+- The form uses `noValidate` to disable native browser validation.
+- All colour values come from the MUI theme (`palette.custom.*` and `palette.primary.*`) — no
+  hardcoded hex values.
+- The social buttons are placeholders — wire up `onGoogleSignUp` / `onFacebookSignUp` to your
+  OAuth flow.

--- a/src/components/SignUpForm.stories.tsx
+++ b/src/components/SignUpForm.stories.tsx
@@ -1,0 +1,66 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { SignUpForm } from "./SignUpForm";
+import { withTheme } from "~/storybooks";
+import { Box } from "@mui/material";
+
+const meta: Meta<typeof SignUpForm> = {
+  title: "Components/SignUpForm",
+  component: SignUpForm,
+  decorators: [
+    withTheme,
+    (Story) => (
+      <Box sx={{ maxWidth: 420, mx: "auto", p: 4 }}>
+        <Story />
+      </Box>
+    ),
+  ],
+  argTypes: {
+    loading: { control: "boolean" },
+    onSubmit: { action: "onSubmit" },
+    onGoogleSignUp: { action: "onGoogleSignUp" },
+    onFacebookSignUp: { action: "onFacebookSignUp" },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof SignUpForm>;
+
+/**
+ * Default empty sign-up form.
+ */
+export const Default: Story = {};
+
+/**
+ * Form with field-level validation errors.
+ */
+export const WithErrors: Story = {
+  args: {
+    errors: {
+      fullName: "Full name is required.",
+      email: "Please enter a valid email address.",
+      password: "Password must be at least 8 characters.",
+      confirmPassword: "Passwords do not match.",
+    },
+  },
+};
+
+/**
+ * General error — e.g. email already registered.
+ */
+export const GeneralError: Story = {
+  args: {
+    errors: {
+      general: "An account with this email already exists.",
+    },
+  },
+};
+
+/**
+ * Loading state — shown while account creation request is in flight.
+ */
+export const Loading: Story = {
+  args: {
+    loading: true,
+  },
+};

--- a/src/components/SignUpForm.tsx
+++ b/src/components/SignUpForm.tsx
@@ -10,6 +10,7 @@ import {
 import VisibilityIcon from "@mui/icons-material/Visibility";
 import VisibilityOffIcon from "@mui/icons-material/VisibilityOff";
 import { useState } from "react";
+import type { Theme } from "@mui/material/styles";
 
 export type SignUpFormValues = {
   fullName: string;
@@ -66,19 +67,31 @@ export function SignUpForm({
     "& .MuiOutlinedInput-root": {
       borderRadius: "8px",
       height: 53,
-      "& fieldset": { borderColor: "#e2e8f0", borderWidth: 2 },
-      "&:hover fieldset": { borderColor: "#94a3b8" },
-      "&.Mui-focused fieldset": { borderColor: "#2563eb" },
+      "& fieldset": {
+        borderColor: (t: Theme) => t.palette.custom.divider,
+        borderWidth: 2,
+      },
+      "&:hover fieldset": {
+        borderColor: (t: Theme) => t.palette.custom.cardImagePlaceholder,
+      },
+      "&.Mui-focused fieldset": {
+        borderColor: (t: Theme) => t.palette.primary.main,
+      },
     },
-    "& input": { fontSize: 14, color: "#0f172a" },
-    "& input::placeholder": { color: "#94a3b8" },
+    "& input": {
+      fontSize: 14,
+      color: (t: Theme) => t.palette.text.primary,
+    },
+    "& input::placeholder": {
+      color: (t: Theme) => t.palette.custom.cardImagePlaceholder,
+    },
   };
 
   const labelSx = {
     display: "block",
     fontSize: 14,
     fontWeight: 500,
-    color: "#334155",
+    color: (t: Theme) => t.palette.custom.labelText,
     mb: 0.75,
   };
 
@@ -90,9 +103,9 @@ export function SignUpForm({
           <Typography
             sx={{
               fontSize: 14,
-              color: "#ef4444",
-              bgcolor: "#fef2f2",
-              border: "1px solid #fecaca",
+              color: (t) => t.palette.custom.errorText,
+              bgcolor: (t) => t.palette.custom.errorBg,
+              border: (t) => `1px solid ${t.palette.custom.errorBorder}`,
               borderRadius: "8px",
               px: 2,
               py: 1.5,
@@ -162,7 +175,7 @@ export function SignUpForm({
                     onClick={() => setShowPassword((prev) => !prev)}
                     edge="end"
                     size="small"
-                    sx={{ color: "#94a3b8" }}
+                    sx={{ color: (t) => t.palette.custom.cardImagePlaceholder }}
                   >
                     {showPassword ? (
                       <VisibilityOffIcon sx={{ fontSize: 20 }} />
@@ -199,7 +212,7 @@ export function SignUpForm({
                     onClick={() => setShowConfirm((prev) => !prev)}
                     edge="end"
                     size="small"
-                    sx={{ color: "#94a3b8" }}
+                    sx={{ color: (t) => t.palette.custom.cardImagePlaceholder }}
                   >
                     {showConfirm ? (
                       <VisibilityOffIcon sx={{ fontSize: 20 }} />
@@ -221,16 +234,16 @@ export function SignUpForm({
           fullWidth
           disabled={loading}
           sx={{
-            bgcolor: "#2563eb",
-            color: "#ffffff",
+            bgcolor: (t) => t.palette.primary.main,
+            color: (t) => t.palette.primary.contrastText,
             fontWeight: 600,
             fontSize: 14,
             borderRadius: "8px",
             height: 49,
             textTransform: "none",
             boxShadow: "none",
-            "&:hover": { bgcolor: "#1d4ed8", boxShadow: "none" },
-            "&:disabled": { bgcolor: "#93c5fd" },
+            "&:hover": { bgcolor: (t) => t.palette.primary.dark, boxShadow: "none" },
+            "&:disabled": { bgcolor: (t) => t.palette.custom.primaryDisabled },
           }}
         >
           {loading ? "Creating account…" : "Create Account"}
@@ -238,11 +251,11 @@ export function SignUpForm({
 
         {/* Divider */}
         <Box sx={{ display: "flex", alignItems: "center", gap: 2 }}>
-          <Box sx={{ flex: 1, height: 1, bgcolor: "#e2e8f0" }} />
-          <Typography sx={{ fontSize: 13, color: "#64748b", whiteSpace: "nowrap" }}>
+          <Box sx={{ flex: 1, height: 1, bgcolor: (t) => t.palette.custom.divider }} />
+          <Typography sx={{ fontSize: 13, color: (t) => t.palette.text.secondary, whiteSpace: "nowrap" }}>
             or continue with
           </Typography>
-          <Box sx={{ flex: 1, height: 1, bgcolor: "#e2e8f0" }} />
+          <Box sx={{ flex: 1, height: 1, bgcolor: (t) => t.palette.custom.divider }} />
         </Box>
 
         {/* Social buttons */}
@@ -258,14 +271,18 @@ export function SignUpForm({
             }
             sx={{
               height: 49,
-              borderColor: "#e2e8f0",
+              borderColor: (t) => t.palette.custom.divider,
               borderWidth: 2,
               borderRadius: "8px",
-              color: "#334155",
+              color: (t) => t.palette.custom.labelText,
               fontWeight: 500,
               fontSize: 14,
               textTransform: "none",
-              "&:hover": { borderColor: "#94a3b8", bgcolor: "#f8fafc", borderWidth: 2 },
+              "&:hover": {
+                borderColor: (t) => t.palette.custom.cardImagePlaceholder,
+                bgcolor: (t) => t.palette.background.default,
+                borderWidth: 2,
+              },
             }}
           >
             Google
@@ -281,14 +298,18 @@ export function SignUpForm({
             }
             sx={{
               height: 49,
-              borderColor: "#e2e8f0",
+              borderColor: (t) => t.palette.custom.divider,
               borderWidth: 2,
               borderRadius: "8px",
-              color: "#334155",
+              color: (t) => t.palette.custom.labelText,
               fontWeight: 500,
               fontSize: 14,
               textTransform: "none",
-              "&:hover": { borderColor: "#94a3b8", bgcolor: "#f8fafc", borderWidth: 2 },
+              "&:hover": {
+                borderColor: (t) => t.palette.custom.cardImagePlaceholder,
+                bgcolor: (t) => t.palette.background.default,
+                borderWidth: 2,
+              },
             }}
           >
             Facebook

--- a/src/components/SignUpForm.tsx
+++ b/src/components/SignUpForm.tsx
@@ -1,0 +1,300 @@
+import {
+  Box,
+  Button,
+  IconButton,
+  InputAdornment,
+  Stack,
+  TextField,
+  Typography,
+} from "@mui/material";
+import VisibilityIcon from "@mui/icons-material/Visibility";
+import VisibilityOffIcon from "@mui/icons-material/VisibilityOff";
+import { useState } from "react";
+
+export type SignUpFormValues = {
+  fullName: string;
+  email: string;
+  password: string;
+  confirmPassword: string;
+};
+
+export type SignUpFormError = {
+  fullName?: string;
+  email?: string;
+  password?: string;
+  confirmPassword?: string;
+  general?: string;
+};
+
+export type SignUpFormProps = {
+  /** Called when the user submits valid registration data. */
+  onSubmit?: (values: SignUpFormValues) => void;
+  /** Called when the user clicks the Google social button. */
+  onGoogleSignUp?: () => void;
+  /** Called when the user clicks the Facebook social button. */
+  onFacebookSignUp?: () => void;
+  /** Validation errors to display. */
+  errors?: SignUpFormError;
+  /** When true the submit button shows a loading state. */
+  loading?: boolean;
+};
+
+/**
+ * Sign-up / registration form with full name, email, password, confirm
+ * password (both with show/hide toggles), and social sign-up buttons.
+ */
+export function SignUpForm({
+  onSubmit,
+  onGoogleSignUp,
+  onFacebookSignUp,
+  errors,
+  loading = false,
+}: SignUpFormProps) {
+  const [fullName, setFullName] = useState("");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [showPassword, setShowPassword] = useState(false);
+  const [showConfirm, setShowConfirm] = useState(false);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    onSubmit?.({ fullName, email, password, confirmPassword });
+  };
+
+  const fieldSx = {
+    "& .MuiOutlinedInput-root": {
+      borderRadius: "8px",
+      height: 53,
+      "& fieldset": { borderColor: "#e2e8f0", borderWidth: 2 },
+      "&:hover fieldset": { borderColor: "#94a3b8" },
+      "&.Mui-focused fieldset": { borderColor: "#2563eb" },
+    },
+    "& input": { fontSize: 14, color: "#0f172a" },
+    "& input::placeholder": { color: "#94a3b8" },
+  };
+
+  const labelSx = {
+    display: "block",
+    fontSize: 14,
+    fontWeight: 500,
+    color: "#334155",
+    mb: 0.75,
+  };
+
+  return (
+    <Box component="form" onSubmit={handleSubmit} noValidate>
+      <Stack spacing={3}>
+        {/* General error */}
+        {errors?.general && (
+          <Typography
+            sx={{
+              fontSize: 14,
+              color: "#ef4444",
+              bgcolor: "#fef2f2",
+              border: "1px solid #fecaca",
+              borderRadius: "8px",
+              px: 2,
+              py: 1.5,
+            }}
+          >
+            {errors.general}
+          </Typography>
+        )}
+
+        {/* Full name */}
+        <Box>
+          <Typography component="label" htmlFor="signup-name" sx={labelSx}>
+            Full Name
+          </Typography>
+          <TextField
+            id="signup-name"
+            type="text"
+            placeholder="Enter your full name"
+            fullWidth
+            value={fullName}
+            onChange={(e) => setFullName(e.target.value)}
+            error={Boolean(errors?.fullName)}
+            helperText={errors?.fullName}
+            inputProps={{ "aria-label": "Full Name" }}
+            sx={fieldSx}
+          />
+        </Box>
+
+        {/* Email */}
+        <Box>
+          <Typography component="label" htmlFor="signup-email" sx={labelSx}>
+            Email Address
+          </Typography>
+          <TextField
+            id="signup-email"
+            type="email"
+            placeholder="Enter your email"
+            fullWidth
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            error={Boolean(errors?.email)}
+            helperText={errors?.email}
+            inputProps={{ "aria-label": "Email Address" }}
+            sx={fieldSx}
+          />
+        </Box>
+
+        {/* Password */}
+        <Box>
+          <Typography component="label" htmlFor="signup-password" sx={labelSx}>
+            Password
+          </Typography>
+          <TextField
+            id="signup-password"
+            type={showPassword ? "text" : "password"}
+            placeholder="Create a password"
+            fullWidth
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            error={Boolean(errors?.password)}
+            helperText={errors?.password}
+            InputProps={{
+              endAdornment: (
+                <InputAdornment position="end">
+                  <IconButton
+                    aria-label={showPassword ? "Hide password" : "Show password"}
+                    onClick={() => setShowPassword((prev) => !prev)}
+                    edge="end"
+                    size="small"
+                    sx={{ color: "#94a3b8" }}
+                  >
+                    {showPassword ? (
+                      <VisibilityOffIcon sx={{ fontSize: 20 }} />
+                    ) : (
+                      <VisibilityIcon sx={{ fontSize: 20 }} />
+                    )}
+                  </IconButton>
+                </InputAdornment>
+              ),
+            }}
+            sx={fieldSx}
+          />
+        </Box>
+
+        {/* Confirm password */}
+        <Box>
+          <Typography component="label" htmlFor="signup-confirm" sx={labelSx}>
+            Confirm Password
+          </Typography>
+          <TextField
+            id="signup-confirm"
+            type={showConfirm ? "text" : "password"}
+            placeholder="Confirm your password"
+            fullWidth
+            value={confirmPassword}
+            onChange={(e) => setConfirmPassword(e.target.value)}
+            error={Boolean(errors?.confirmPassword)}
+            helperText={errors?.confirmPassword}
+            InputProps={{
+              endAdornment: (
+                <InputAdornment position="end">
+                  <IconButton
+                    aria-label={showConfirm ? "Hide confirm password" : "Show confirm password"}
+                    onClick={() => setShowConfirm((prev) => !prev)}
+                    edge="end"
+                    size="small"
+                    sx={{ color: "#94a3b8" }}
+                  >
+                    {showConfirm ? (
+                      <VisibilityOffIcon sx={{ fontSize: 20 }} />
+                    ) : (
+                      <VisibilityIcon sx={{ fontSize: 20 }} />
+                    )}
+                  </IconButton>
+                </InputAdornment>
+              ),
+            }}
+            sx={fieldSx}
+          />
+        </Box>
+
+        {/* Submit */}
+        <Button
+          type="submit"
+          variant="contained"
+          fullWidth
+          disabled={loading}
+          sx={{
+            bgcolor: "#2563eb",
+            color: "#ffffff",
+            fontWeight: 600,
+            fontSize: 14,
+            borderRadius: "8px",
+            height: 49,
+            textTransform: "none",
+            boxShadow: "none",
+            "&:hover": { bgcolor: "#1d4ed8", boxShadow: "none" },
+            "&:disabled": { bgcolor: "#93c5fd" },
+          }}
+        >
+          {loading ? "Creating account…" : "Create Account"}
+        </Button>
+
+        {/* Divider */}
+        <Box sx={{ display: "flex", alignItems: "center", gap: 2 }}>
+          <Box sx={{ flex: 1, height: 1, bgcolor: "#e2e8f0" }} />
+          <Typography sx={{ fontSize: 13, color: "#64748b", whiteSpace: "nowrap" }}>
+            or continue with
+          </Typography>
+          <Box sx={{ flex: 1, height: 1, bgcolor: "#e2e8f0" }} />
+        </Box>
+
+        {/* Social buttons */}
+        <Stack direction="row" spacing={1.5}>
+          <Button
+            variant="outlined"
+            fullWidth
+            onClick={onGoogleSignUp}
+            startIcon={
+              <Typography component="span" sx={{ fontSize: 16, lineHeight: 1 }}>
+                G
+              </Typography>
+            }
+            sx={{
+              height: 49,
+              borderColor: "#e2e8f0",
+              borderWidth: 2,
+              borderRadius: "8px",
+              color: "#334155",
+              fontWeight: 500,
+              fontSize: 14,
+              textTransform: "none",
+              "&:hover": { borderColor: "#94a3b8", bgcolor: "#f8fafc", borderWidth: 2 },
+            }}
+          >
+            Google
+          </Button>
+          <Button
+            variant="outlined"
+            fullWidth
+            onClick={onFacebookSignUp}
+            startIcon={
+              <Typography component="span" sx={{ fontSize: 16, lineHeight: 1 }}>
+                f
+              </Typography>
+            }
+            sx={{
+              height: 49,
+              borderColor: "#e2e8f0",
+              borderWidth: 2,
+              borderRadius: "8px",
+              color: "#334155",
+              fontWeight: 500,
+              fontSize: 14,
+              textTransform: "none",
+              "&:hover": { borderColor: "#94a3b8", bgcolor: "#f8fafc", borderWidth: 2 },
+            }}
+          >
+            Facebook
+          </Button>
+        </Stack>
+      </Stack>
+    </Box>
+  );
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,6 +1,12 @@
 export { AppHeader } from './AppHeader';
 export type { AppHeaderProps, NavLink } from './AppHeader';
 export { AppFooter } from './AppFooter';
+export { AuthHeroPanel } from './AuthHeroPanel';
+export type { AuthHeroPanelProps } from './AuthHeroPanel';
+export { SignInForm } from './SignInForm';
+export type { SignInFormProps, SignInFormValues, SignInFormError } from './SignInForm';
+export { SignUpForm } from './SignUpForm';
+export type { SignUpFormProps, SignUpFormValues, SignUpFormError } from './SignUpForm';
 export { CarCard } from './CarCard';
 export type { CarCardProps } from './CarCard';
 export { CategoryCard } from './CategoryCard';

--- a/src/pages/AuthPage.mdx
+++ b/src/pages/AuthPage.mdx
@@ -1,0 +1,77 @@
+{/* src/pages/AuthPage.mdx */}
+
+import { Meta, Canvas, Controls } from "@storybook/addon-docs/blocks";
+import * as AuthPageStories from "./AuthPage.stories";
+
+<Meta of={AuthPageStories} />
+
+# AuthPage
+
+Full-screen authentication page that composes the `AuthHeroPanel`, `SignInForm`, and `SignUpForm`
+components into a split-screen layout.
+
+The left half shows the decorative hero panel (hidden on mobile). The right half contains a
+tabbed form panel with "Sign In" and "Register" tabs, a logo lockup, and a contextual footer
+link. The active tab is controlled internally; `initialTab` sets the starting state.
+
+Component hierarchy: `App -> AuthPage -> [AuthHeroPanel, SignInForm | SignUpForm]`
+
+## Usage
+
+<Canvas of={AuthPageStories.SignIn} />
+<Controls of={AuthPageStories.SignIn} />
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `initialTab` | `"signin" \| "signup"` | `"signin"` | Which tab is active when the page first renders. |
+| `onSignIn` | `(values: SignInFormValues) => void` | — | Called when the sign-in form is submitted. |
+| `onSignUp` | `(values: SignUpFormValues) => void` | — | Called when the sign-up form is submitted. |
+| `onForgotPassword` | `() => void` | — | Called when the user clicks "Forgot password?". |
+| `onGoogleAuth` | `() => void` | — | Called when Google auth is triggered from either form. |
+| `onFacebookAuth` | `() => void` | — | Called when Facebook auth is triggered from either form. |
+| `signInErrors` | `SignInFormError` | — | Validation errors forwarded to `SignInForm`. |
+| `signUpErrors` | `SignUpFormError` | — | Validation errors forwarded to `SignUpForm`. |
+| `loading` | `boolean` | `false` | Shows a loading state on the active form's submit button. |
+
+## Variants
+
+### Register tab
+
+<Canvas of={AuthPageStories.Register} />
+
+Pass `initialTab="signup"` to land on the registration form. The tab and footer link update
+accordingly.
+
+### Sign-in with errors
+
+<Canvas of={AuthPageStories.SignInWithErrors} />
+
+Pass `signInErrors` to surface authentication failures (e.g. wrong credentials) as a general
+error banner inside the sign-in form.
+
+### Sign-up with errors
+
+<Canvas of={AuthPageStories.SignUpWithErrors} />
+
+Pass `signUpErrors` to surface field-level validation failures inside the registration form.
+
+### Loading
+
+<Canvas of={AuthPageStories.SignInLoading} />
+
+Pass `loading={true}` while an auth request is in flight. The active form's submit button
+disables and shows a pending label.
+
+## Design notes
+
+- The layout is a full-viewport flex row. `AuthHeroPanel` takes `flex: 1` on the left; the form
+  panel takes `flex: 1` on the right, centred with a `maxWidth` of 420 px.
+- The hero panel is hidden via `display: { xs: "none", md: "flex" }`, giving the form panel the
+  full width on mobile.
+- The `onGoogleAuth` / `onFacebookAuth` props are forwarded to both forms so a single handler
+  works regardless of which tab is active.
+- The tab indicator and selected tab colour come from `palette.primary.main`; the divider from
+  `palette.custom.divider`.
+- Matches Figma design node `8-2111` in the Autocare file.

--- a/src/pages/AuthPage.stories.tsx
+++ b/src/pages/AuthPage.stories.tsx
@@ -1,0 +1,78 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { AuthPage } from "./AuthPage";
+import { withTheme } from "~/storybooks";
+
+const meta: Meta<typeof AuthPage> = {
+  title: "Pages/AuthPage",
+  component: AuthPage,
+  decorators: [withTheme],
+  parameters: {
+    layout: "fullscreen",
+  },
+  argTypes: {
+    loading: { control: "boolean" },
+    initialTab: { control: { type: "radio" }, options: ["signin", "signup"] },
+    onSignIn: { action: "onSignIn" },
+    onSignUp: { action: "onSignUp" },
+    onForgotPassword: { action: "onForgotPassword" },
+    onGoogleAuth: { action: "onGoogleAuth" },
+    onFacebookAuth: { action: "onFacebookAuth" },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof AuthPage>;
+
+/**
+ * Default view — Sign In tab active.
+ */
+export const SignIn: Story = {
+  args: {
+    initialTab: "signin",
+  },
+};
+
+/**
+ * Register tab active.
+ */
+export const Register: Story = {
+  args: {
+    initialTab: "signup",
+  },
+};
+
+/**
+ * Sign-in tab with validation errors shown.
+ */
+export const SignInWithErrors: Story = {
+  args: {
+    initialTab: "signin",
+    signInErrors: {
+      general: "The email or password you entered is incorrect.",
+    },
+  },
+};
+
+/**
+ * Sign-up tab with field-level validation errors.
+ */
+export const SignUpWithErrors: Story = {
+  args: {
+    initialTab: "signup",
+    signUpErrors: {
+      email: "An account with this email already exists.",
+      confirmPassword: "Passwords do not match.",
+    },
+  },
+};
+
+/**
+ * Loading state during sign-in submission.
+ */
+export const SignInLoading: Story = {
+  args: {
+    initialTab: "signin",
+    loading: true,
+  },
+};

--- a/src/pages/AuthPage.tsx
+++ b/src/pages/AuthPage.tsx
@@ -1,0 +1,221 @@
+import { Box, Tab, Tabs, Typography } from "@mui/material";
+import { useState } from "react";
+import { AuthHeroPanel } from "~/components/AuthHeroPanel";
+import { SignInForm, type SignInFormValues, type SignInFormError } from "~/components/SignInForm";
+import { SignUpForm, type SignUpFormValues, type SignUpFormError } from "~/components/SignUpForm";
+
+type AuthTab = "signin" | "signup";
+
+export type AuthPageProps = {
+  /** Initial tab to show. Defaults to "signin". */
+  initialTab?: AuthTab;
+  /** Called when the sign-in form is submitted. */
+  onSignIn?: (values: SignInFormValues) => void;
+  /** Called when the sign-up form is submitted. */
+  onSignUp?: (values: SignUpFormValues) => void;
+  /** Called when the user clicks "Forgot password?". */
+  onForgotPassword?: () => void;
+  /** Called when Google auth is triggered from either form. */
+  onGoogleAuth?: () => void;
+  /** Called when Facebook auth is triggered from either form. */
+  onFacebookAuth?: () => void;
+  /** Sign-in validation errors. */
+  signInErrors?: SignInFormError;
+  /** Sign-up validation errors. */
+  signUpErrors?: SignUpFormError;
+  /** Show loading state on the active form's submit button. */
+  loading?: boolean;
+};
+
+/**
+ * Full-screen authentication page.
+ *
+ * Layout: split-screen — hero panel on the left (hidden on mobile),
+ * form panel on the right with Sign In / Register tabs.
+ *
+ * App -> Pages -> AuthPage -> [AuthHeroPanel, SignInForm | SignUpForm]
+ */
+export function AuthPage({
+  initialTab = "signin",
+  onSignIn,
+  onSignUp,
+  onForgotPassword,
+  onGoogleAuth,
+  onFacebookAuth,
+  signInErrors,
+  signUpErrors,
+  loading = false,
+}: AuthPageProps) {
+  const [activeTab, setActiveTab] = useState<AuthTab>(initialTab);
+
+  return (
+    <Box sx={{ display: "flex", minHeight: "100vh", bgcolor: "#f8fafc" }}>
+      {/* Left hero panel — hidden on mobile */}
+      <AuthHeroPanel />
+
+      {/* Right form panel */}
+      <Box
+        sx={{
+          flex: 1,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          py: { xs: 6, md: 5 },
+          px: { xs: 3, sm: 6 },
+          overflowY: "auto",
+        }}
+      >
+        <Box sx={{ width: "100%", maxWidth: 420 }}>
+          {/* Logo */}
+          <Box
+            component="a"
+            href="/"
+            aria-label="AutoExchange home"
+            sx={{
+              display: "flex",
+              alignItems: "center",
+              gap: 1.5,
+              textDecoration: "none",
+              mb: 4,
+            }}
+          >
+            <Box
+              sx={{
+                width: 40,
+                height: 40,
+                bgcolor: "#2563eb",
+                borderRadius: "8px",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                flexShrink: 0,
+              }}
+            >
+              <Typography sx={{ fontSize: 20, lineHeight: 1 }}>{"⏱"}</Typography>
+            </Box>
+            <Typography
+              sx={{
+                fontFamily: "'Barlow', sans-serif",
+                fontWeight: 700,
+                fontSize: 24,
+                color: "#0f172a",
+                lineHeight: 1,
+              }}
+            >
+              AutoExchange
+            </Typography>
+          </Box>
+
+          {/* Heading */}
+          <Typography
+            sx={{
+              fontFamily: "'Barlow', sans-serif",
+              fontSize: 32,
+              lineHeight: "38.4px",
+              color: "#0f172a",
+              mb: 0.75,
+            }}
+          >
+            {activeTab === "signin" ? "Welcome Back" : "Create Account"}
+          </Typography>
+          <Typography sx={{ fontSize: 14, color: "#64748b", mb: 3 }}>
+            {activeTab === "signin"
+              ? "Sign in to access your account and manage your listings."
+              : "Join AutoExchange and start browsing or listing cars today."}
+          </Typography>
+
+          {/* Tabs */}
+          <Tabs
+            value={activeTab}
+            onChange={(_, value: AuthTab) => setActiveTab(value)}
+            sx={{
+              borderBottom: "2px solid #e2e8f0",
+              mb: 3,
+              "& .MuiTabs-indicator": {
+                bgcolor: "#2563eb",
+                height: 2,
+              },
+              "& .MuiTab-root": {
+                textTransform: "none",
+                fontSize: 14,
+                fontWeight: 600,
+                color: "#64748b",
+                flex: 1,
+                minHeight: 53,
+                "&.Mui-selected": { color: "#2563eb" },
+              },
+            }}
+          >
+            <Tab label="Sign In" value="signin" id="tab-signin" aria-controls="tabpanel-signin" />
+            <Tab label="Register" value="signup" id="tab-signup" aria-controls="tabpanel-signup" />
+          </Tabs>
+
+          {/* Form panel */}
+          <Box
+            role="tabpanel"
+            id={`tabpanel-${activeTab}`}
+            aria-labelledby={`tab-${activeTab}`}
+          >
+            {activeTab === "signin" ? (
+              <SignInForm
+                onSubmit={onSignIn}
+                onForgotPassword={onForgotPassword}
+                onGoogleSignIn={onGoogleAuth}
+                onFacebookSignIn={onFacebookAuth}
+                errors={signInErrors}
+                loading={loading}
+              />
+            ) : (
+              <SignUpForm
+                onSubmit={onSignUp}
+                onGoogleSignUp={onGoogleAuth}
+                onFacebookSignUp={onFacebookAuth}
+                errors={signUpErrors}
+                loading={loading}
+              />
+            )}
+          </Box>
+
+          {/* Footer link */}
+          <Typography
+            sx={{ fontSize: 14, color: "#64748b", textAlign: "center", mt: 3 }}
+          >
+            {activeTab === "signin" ? (
+              <>
+                {"Don't have an account? "}
+                <Typography
+                  component="span"
+                  onClick={() => setActiveTab("signup")}
+                  sx={{
+                    fontWeight: 500,
+                    color: "#2563eb",
+                    cursor: "pointer",
+                    "&:hover": { textDecoration: "underline" },
+                  }}
+                >
+                  Sign up
+                </Typography>
+              </>
+            ) : (
+              <>
+                {"Already have an account? "}
+                <Typography
+                  component="span"
+                  onClick={() => setActiveTab("signin")}
+                  sx={{
+                    fontWeight: 500,
+                    color: "#2563eb",
+                    cursor: "pointer",
+                    "&:hover": { textDecoration: "underline" },
+                  }}
+                >
+                  Sign in
+                </Typography>
+              </>
+            )}
+          </Typography>
+        </Box>
+      </Box>
+    </Box>
+  );
+}

--- a/src/pages/AuthPage.tsx
+++ b/src/pages/AuthPage.tsx
@@ -49,7 +49,7 @@ export function AuthPage({
   const [activeTab, setActiveTab] = useState<AuthTab>(initialTab);
 
   return (
-    <Box sx={{ display: "flex", minHeight: "100vh", bgcolor: "#f8fafc" }}>
+    <Box sx={{ display: "flex", minHeight: "100vh", bgcolor: (t) => t.palette.background.default }}>
       {/* Left hero panel — hidden on mobile */}
       <AuthHeroPanel />
 
@@ -83,7 +83,7 @@ export function AuthPage({
               sx={{
                 width: 40,
                 height: 40,
-                bgcolor: "#2563eb",
+                bgcolor: (t) => t.palette.primary.main,
                 borderRadius: "8px",
                 display: "flex",
                 alignItems: "center",
@@ -98,7 +98,7 @@ export function AuthPage({
                 fontFamily: "'Barlow', sans-serif",
                 fontWeight: 700,
                 fontSize: 24,
-                color: "#0f172a",
+                color: (t) => t.palette.text.primary,
                 lineHeight: 1,
               }}
             >
@@ -112,13 +112,13 @@ export function AuthPage({
               fontFamily: "'Barlow', sans-serif",
               fontSize: 32,
               lineHeight: "38.4px",
-              color: "#0f172a",
+              color: (t) => t.palette.text.primary,
               mb: 0.75,
             }}
           >
             {activeTab === "signin" ? "Welcome Back" : "Create Account"}
           </Typography>
-          <Typography sx={{ fontSize: 14, color: "#64748b", mb: 3 }}>
+          <Typography sx={{ fontSize: 14, color: (t) => t.palette.text.secondary, mb: 3 }}>
             {activeTab === "signin"
               ? "Sign in to access your account and manage your listings."
               : "Join AutoExchange and start browsing or listing cars today."}
@@ -129,20 +129,20 @@ export function AuthPage({
             value={activeTab}
             onChange={(_, value: AuthTab) => setActiveTab(value)}
             sx={{
-              borderBottom: "2px solid #e2e8f0",
+              borderBottom: (t) => `2px solid ${t.palette.custom.divider}`,
               mb: 3,
               "& .MuiTabs-indicator": {
-                bgcolor: "#2563eb",
+                bgcolor: (t) => t.palette.primary.main,
                 height: 2,
               },
               "& .MuiTab-root": {
                 textTransform: "none",
                 fontSize: 14,
                 fontWeight: 600,
-                color: "#64748b",
+                color: (t) => t.palette.text.secondary,
                 flex: 1,
                 minHeight: 53,
-                "&.Mui-selected": { color: "#2563eb" },
+                "&.Mui-selected": { color: (t) => t.palette.primary.main },
               },
             }}
           >
@@ -178,7 +178,7 @@ export function AuthPage({
 
           {/* Footer link */}
           <Typography
-            sx={{ fontSize: 14, color: "#64748b", textAlign: "center", mt: 3 }}
+            sx={{ fontSize: 14, color: (t) => t.palette.text.secondary, textAlign: "center", mt: 3 }}
           >
             {activeTab === "signin" ? (
               <>
@@ -188,7 +188,7 @@ export function AuthPage({
                   onClick={() => setActiveTab("signup")}
                   sx={{
                     fontWeight: 500,
-                    color: "#2563eb",
+                    color: (t) => t.palette.primary.main,
                     cursor: "pointer",
                     "&:hover": { textDecoration: "underline" },
                   }}
@@ -204,7 +204,7 @@ export function AuthPage({
                   onClick={() => setActiveTab("signin")}
                   sx={{
                     fontWeight: 500,
-                    color: "#2563eb",
+                    color: (t) => t.palette.primary.main,
                     cursor: "pointer",
                     "&:hover": { textDecoration: "underline" },
                   }}

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -1,3 +1,5 @@
+export { AuthPage } from "./AuthPage";
+export type { AuthPageProps } from "./AuthPage";
 export { CarDetailPage } from "./CarDetailPage";
 export { DashboardPage } from "./DashboardPage";
 export type { DashboardPageProps } from "./DashboardPage";

--- a/src/theme/README.md
+++ b/src/theme/README.md
@@ -45,6 +45,13 @@ These extend MUI's palette via TypeScript module augmentation (see bottom of `in
 | `palette.custom.cardImagePlaceholder` | `#94a3b8` | Car card image placeholder icon fill |
 | `palette.custom.divider` | `#e2e8f0` | Horizontal/vertical dividers |
 | `palette.custom.navbarBg` | `#0f172a` | Top navbar background |
+| `palette.custom.labelText` | `#334155` | Form field label text (slate-700) |
+| `palette.custom.checkboxUnchecked` | `#cbd5e1` | Unchecked checkbox border colour (slate-300) |
+| `palette.custom.primaryDisabled` | `#93c5fd` | Disabled primary button background (blue-300) |
+| `palette.custom.errorText` | `#ef4444` | Inline error message text colour (red-500) |
+| `palette.custom.errorBg` | `#fef2f2` | Error alert / banner background (red-50) |
+| `palette.custom.errorBorder` | `#fecaca` | Error alert / banner border (red-200) |
+| `palette.custom.heroPanelGradientEnd` | `#334155` | Auth hero panel gradient end colour (slate-700) |
 
 ---
 

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -56,6 +56,14 @@ const theme = createTheme({
       cardImagePlaceholder: "#94a3b8",
       divider: "#e2e8f0",
       navbarBg: "#0f172a",
+      // Auth page tokens
+      labelText: "#334155",           // slate-700 — form field labels
+      checkboxUnchecked: "#cbd5e1",   // slate-300 — unchecked checkbox border
+      primaryDisabled: "#93c5fd",     // blue-300 — disabled primary button background
+      errorText: "#ef4444",           // red-500 — inline error message text
+      errorBg: "#fef2f2",             // red-50 — error alert background
+      errorBorder: "#fecaca",         // red-200 — error alert border
+      heroPanelGradientEnd: "#334155",// slate-700 — hero panel gradient end colour
     },
   },
 
@@ -101,6 +109,14 @@ declare module "@mui/material/styles" {
       cardImagePlaceholder: string;
       divider: string;
       navbarBg: string;
+      // Auth page tokens
+      labelText: string;
+      checkboxUnchecked: string;
+      primaryDisabled: string;
+      errorText: string;
+      errorBg: string;
+      errorBorder: string;
+      heroPanelGradientEnd: string;
     };
   }
   interface PaletteOptions {
@@ -112,6 +128,14 @@ declare module "@mui/material/styles" {
       cardImagePlaceholder?: string;
       divider?: string;
       navbarBg?: string;
+      // Auth page tokens
+      labelText?: string;
+      checkboxUnchecked?: string;
+      primaryDisabled?: string;
+      errorText?: string;
+      errorBg?: string;
+      errorBorder?: string;
+      heroPanelGradientEnd?: string;
     };
   }
 }


### PR DESCRIPTION
## Summary

- Built `AuthHeroPanel` — dark gradient left panel with car emoji and tagline, hidden on mobile
- Built `SignInForm` — email field, password with show/hide toggle, remember me checkbox, forgot password link, Sign In button, social sign-in buttons (Google / Facebook), error and loading states
- Built `SignUpForm` — full name, email, password + confirm password (both with show/hide toggles), social sign-up buttons, error and loading states
- Built `AuthPage` — composes hero panel and tabbed form panel (Sign In / Register tabs), matches Figma design node `8-2111`
- Exported all new components from `src/components/index.ts` and `src/pages/index.ts`
- Storybook stories for every component covering default, error, and loading states (15 stories total)

Closes #37

🤖 Generated by UI Agent