### PR TITLE
fix(store): enforce relative imports for intra-module paths

### DIFF
--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,7 +1,7 @@
 import { create } from "zustand";
-import { StoreState } from "~/store/types";
-import { createCarsSlice } from "~/store/slices/cars.slice";
-import { createFiltersSlice } from "~/store/slices/filters.slice";
+import { StoreState } from "./types";
+import { createCarsSlice } from "./slices/cars.slice";
+import { createFiltersSlice } from "./slices/filters.slice";
 
 export const useAppStore = create<StoreState>()((...args) => ({
   ...createCarsSlice(...args),

--- a/src/store/slices/cars.slice.ts
+++ b/src/store/slices/cars.slice.ts
@@ -1,6 +1,6 @@
 import { StateCreator } from "zustand";
 import { Car } from "~/types";
-import { StoreState } from "~/store/types";
+import { StoreState } from "../types";
 
 export type CarsSlice = {
   cars: Car[];

--- a/src/store/slices/filters.slice.ts
+++ b/src/store/slices/filters.slice.ts
@@ -1,6 +1,6 @@
 import { StateCreator } from "zustand";
 import { FuelType, Transmission } from "~/types";
-import { StoreState } from "~/store/types";
+import { StoreState } from "../types";
 
 export type FiltersSlice = {
   filters: {

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -1,4 +1,4 @@
-import { CarsSlice } from "~/store/slices/cars.slice";
-import { FiltersSlice } from "~/store/slices/filters.slice";
+import { CarsSlice } from "./slices/cars.slice";
+import { FiltersSlice } from "./slices/filters.slice";
 
 export type StoreState = CarsSlice & FiltersSlice;


### PR DESCRIPTION
## Summary
- Fixed all 7 import path violations in `src/store/` where `~/store/...` alias was used for imports within the same module
- `src/store/index.ts`: changed `~/store/types` to `./types`, `~/store/slices/cars.slice` to `./slices/cars.slice`, `~/store/slices/filters.slice` to `./slices/filters.slice`
- `src/store/types.ts`: changed `~/store/slices/cars.slice` to `./slices/cars.slice`, `~/store/slices/filters.slice` to `./slices/filters.slice`
- `src/store/slices/cars.slice.ts`: changed `~/store/types` to `../types`
- `src/store/slices/filters.slice.ts`: changed `~/store/types` to `../types`
- Cross-module imports using `~/types` are intentionally preserved (they are correct per the convention)
- `yarn typecheck` passes with zero errors

Closes #18

🤖 Generated by DevOps Agent