### PR TITLE
feat(ui): build home/browse page layout + Storybook (#12)

### DIFF
--- a/.claude/agents/ui.md
+++ b/.claude/agents/ui.md
@@ -157,6 +157,12 @@ Always import blocks from `@storybook/addon-docs/blocks` — not from `@storyboo
 import { Meta, Canvas, Controls } from "@storybook/addon-docs/blocks";
 ```
 
+## Component structure rules
+
+- **One component per file**: Each file in `src/components/` must export exactly one primary component. The only exception is when you need to split a component into `ComponentOuter` / `ComponentInner` pairs (e.g. to wrap with `React.Suspense`).
+- **Page files contain only the page component**: Files in `src/pages/` must contain only the named page component (e.g. `HomePage`). Any secondary UI element that could stand alone must be extracted to `src/components/` with its own story and MDX file.
+- **Internal section helpers are allowed**: A page file may define private section-level functions (e.g. `WhyChooseUsSection`) that exist solely to keep the page component readable — provided they are not reusable outside the page and are not exported. Reusable components must always live in `src/components/`.
+
 ## Workflow
 
 1. Post to Slack that you have started the task.

--- a/.claude/skills/implement-ui/SKILL.md
+++ b/.claude/skills/implement-ui/SKILL.md
@@ -22,6 +22,7 @@ The project uses **React** with **Material UI (MUI)** exclusively. Key rules fro
 - **Structure**: App → Pages → Sections → Components. Components are the building blocks.
 - **Separation**: Keep presentation and data separate. All presentational components go in `src/components/`.
 - **Composability**: Build small, composable components that can be nested. Avoid large monolithic components.
+- **One component per file**: Each file in `src/components/` must export exactly one primary component. The only exception is when you need to split a component into `ComponentOuter` / `ComponentInner` pairs (e.g. to wrap with `React.Suspense`). Page files (`src/pages/`) must contain only the page component — any secondary UI element that could stand alone should be extracted to `src/components/`.
 - **Hooks**: Extract reusable logic into hooks. Check `src/components/readme.md` for existing hooks before creating new ones. New hooks go in `src/components/hooks/`.
 - **Storybook**: Every component needs a corresponding Storybook story.
 - **Exports**: Export both the component and its props type from the component file. Re-export through `src/components/index.ts`.

--- a/src/components/HeroStats.mdx
+++ b/src/components/HeroStats.mdx
@@ -1,0 +1,29 @@
+{/* src/components/HeroStats.mdx */}
+
+import { Meta, Canvas, Controls } from "@storybook/addon-docs/blocks";
+import * as HeroStatsStories from "./HeroStats.stories";
+
+<Meta of={HeroStatsStories} />
+
+# HeroStats
+
+A dark stats bar displayed directly below the hero section on the home page. Shows three
+platform-wide metrics (listings count, dealers count, satisfaction rate) side by side on a
+`heroStatsBg` themed dark background.
+
+## Usage
+
+<Canvas of={HeroStatsStories.Default} />
+<Controls of={HeroStatsStories.Default} />
+
+## Props
+
+This component takes no props. The stat values are static display data defined internally.
+
+## Design notes
+
+- Background colour uses the `palette.custom.heroStatsBg` theme token (slate-800 / `#1e293b`).
+- Stat values use Barlow at `32px` / `fontWeight: 700`; labels use Inter at `14px`.
+- The layout is a centred flex row with `gap: { xs: 4, md: 10 }` and `flexWrap: "wrap"` so it
+  stacks gracefully on narrow viewports.
+- Placed between `DashboardHero` and the first content section in the `HomePage` composition.

--- a/src/components/HeroStats.stories.tsx
+++ b/src/components/HeroStats.stories.tsx
@@ -1,0 +1,22 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { HeroStats } from "./HeroStats";
+import { withTheme } from "~/storybooks";
+
+const meta: Meta<typeof HeroStats> = {
+  title: "Components/HeroStats",
+  component: HeroStats,
+  decorators: [withTheme],
+  parameters: {
+    layout: "fullscreen",
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof HeroStats>;
+
+/**
+ * Stats bar as shown below the hero on the home page.
+ * Displays three platform-wide metrics on a dark background.
+ */
+export const Default: Story = {};

--- a/src/components/HeroStats.tsx
+++ b/src/components/HeroStats.tsx
@@ -1,0 +1,61 @@
+import { Box, Typography } from "@mui/material";
+
+const STATS = [
+  { value: "50K+", label: "Listings" },
+  { value: "12K+", label: "Dealers" },
+  { value: "98%", label: "Satisfaction" },
+];
+
+/**
+ * Dark stats bar displayed below the hero section on the home page.
+ * Shows three platform-wide metrics side by side.
+ */
+export function HeroStats() {
+  return (
+    <Box
+      sx={{
+        bgcolor: (t) => t.palette.custom.heroStatsBg,
+        py: 3,
+        px: 2,
+      }}
+    >
+      <Box
+        sx={{
+          maxWidth: 1456,
+          mx: "auto",
+          px: { xs: 2, md: 5 },
+          display: "flex",
+          justifyContent: "center",
+          gap: { xs: 4, md: 10 },
+          flexWrap: "wrap",
+        }}
+      >
+        {STATS.map(({ value, label }) => (
+          <Box key={label} sx={{ textAlign: "center" }}>
+            <Typography
+              sx={{
+                fontFamily: "'Barlow', sans-serif",
+                fontWeight: 700,
+                fontSize: { xs: 24, md: 32 },
+                color: (t) => t.palette.primary.contrastText,
+                lineHeight: 1,
+              }}
+            >
+              {value}
+            </Typography>
+            <Typography
+              sx={{
+                fontFamily: "'Inter', sans-serif",
+                fontSize: 14,
+                color: (t) => t.palette.custom.cardImagePlaceholder,
+                mt: 0.5,
+              }}
+            >
+              {label}
+            </Typography>
+          </Box>
+        ))}
+      </Box>
+    </Box>
+  );
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -9,6 +9,7 @@ export { DashboardHeader } from './DashboardHeader';
 export type { DashboardHeaderProps, DashboardHeaderNavLink } from './DashboardHeader';
 export { DashboardHero } from './DashboardHero';
 export type { DashboardHeroProps } from './DashboardHero';
+export { HeroStats } from './HeroStats';
 export { ListingCard } from './ListingCard';
 export type { ListingCardProps, ListingBadge } from './ListingCard';
 export { RootLayout } from './RootLayout';

--- a/src/pages/HomePage.mdx
+++ b/src/pages/HomePage.mdx
@@ -1,32 +1,59 @@
 {/* src/pages/HomePage.mdx */}
 
-import { Meta, Canvas } from "@storybook/addon-docs/blocks";
+import { Meta, Canvas, Controls } from "@storybook/addon-docs/blocks";
 import * as HomePageStories from "./HomePage.stories";
 
 <Meta of={HomePageStories} />
 
 # HomePage
 
-The root landing page of the AutoExchange application, served at `/`. It provides an entry point
-for visitors to discover and browse vehicle listings.
+The main landing / browse page of the Autocare application. Composes all hero, marketing, and
+listing sections into a full-page layout wired to the Zustand car store.
 
 ## Usage
 
 <Canvas of={HomePageStories.Default} />
+<Controls of={HomePageStories.Default} />
 
-## Overview
+## Props
 
-`HomePage` is a page-level component with no props of its own. It is composed inside the
-application router and inherits the theme via the `withTheme` decorator in Storybook.
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `onSearch` | `(keyword: string, zipCode: string) => void` | `undefined` | Called when the hero search bar is submitted. |
+| `onViewDetails` | `(id: string) => void` | `() => {}` | Called when a car card's "View Details" button is clicked. |
+| `onFavourite` | `(id: string) => void` | `() => {}` | Called when a car card's favourite button is clicked. |
+| `onViewAllCars` | `() => void` | `undefined` | Called when "View All" is clicked in the Trending Cars section. |
+| `onMakeClick` | `(make: string) => void` | `undefined` | Called when a brand card in the Popular Makes section is clicked. |
+| `onSellClick` | `() => void` | `undefined` | Called when the "Sell My Car" button in the sell banner is clicked. |
 
-Current state: the page contains a welcome heading and a descriptive tagline. It serves as a
-scaffold for the full browse/discovery experience that will be built out in subsequent issues.
+## With actions
+
+<Canvas of={HomePageStories.WithActions} />
+
+Use the Actions panel in Storybook to see callbacks fire when interacting with the page.
+
+## Page sections
+
+The page is composed of the following sections in order:
+
+1. **DashboardHero** — dark hero with headline, search bar, and background image.
+2. **HeroStats** — stats bar displaying platform-wide metrics (50K+ listings, 12K+ dealers, 98% satisfaction).
+3. **Why Choose Us** — four `CategoryCard` tiles highlighting platform benefits.
+4. **Popular Makes** — six `CategoryCard` tiles for top car brands, each optionally clickable.
+5. **Trending Cars** — up to four `CarCard` tiles sourced from the `useFilteredCars` store hook.
+6. **How It Works** — three-step process explanation.
+7. **SellBanner** — call-to-action for sellers.
+8. **AppFooter** — site-wide footer.
+
+## Data
+
+Trending Cars data is read from the Zustand car store via `useFilteredCars()`. In Storybook, the
+`withMockStore` decorator seeds the store with mock data so the section renders real listings.
 
 ## Design notes
 
-- The page uses MUI `Container` with `maxWidth="lg"` and `py: 4` padding for consistent layout
-  within the `RootLayout` shell.
-- All copy should remain in sync with the brand name — currently "Autoshop" in the heading. Update
-  when the brand guidelines are finalised.
-- As the page grows, extract sub-sections (hero banner, listing grid, filters) into their own
-  components and document each separately.
+- All sections use a `maxWidth: 1456` inner container with `px: { xs: 2, md: 5 }` horizontal
+  padding for consistent alignment.
+- Alternating section backgrounds (`background.default` / `background.paper`) create visual
+  separation between content groups.
+- The page renders as `<Box component="main">` for semantic HTML landmark structure.

--- a/src/pages/HomePage.stories.tsx
+++ b/src/pages/HomePage.stories.tsx
@@ -3,7 +3,7 @@ import { createRoutesStub } from "react-router";
 import React from "react";
 import type { Decorator } from "@storybook/react";
 import { HomePage } from "./HomePage";
-import { withTheme } from "~/storybooks";
+import { withTheme, withMockStore } from "~/storybooks";
 
 const withRouter: Decorator = (Story) => {
   const Stub = createRoutesStub([{ path: "/", Component: Story }]);
@@ -13,11 +13,41 @@ const withRouter: Decorator = (Story) => {
 const meta: Meta<typeof HomePage> = {
   title: "Pages/HomePage",
   component: HomePage,
-  decorators: [withTheme, withRouter],
+  decorators: [withTheme, withMockStore, withRouter],
+  parameters: {
+    layout: "fullscreen",
+  },
+  argTypes: {
+    onSearch: { action: "onSearch" },
+    onViewDetails: { action: "onViewDetails" },
+    onFavourite: { action: "onFavourite" },
+    onViewAllCars: { action: "onViewAllCars" },
+    onMakeClick: { action: "onMakeClick" },
+    onSellClick: { action: "onSellClick" },
+  },
 };
 
 export default meta;
 
 type Story = StoryObj<typeof HomePage>;
 
+/**
+ * Full home page layout with all sections composed together.
+ * The store is seeded with mock car data so the Trending Cars section
+ * renders real listings.
+ */
 export const Default: Story = {};
+
+/**
+ * With action handlers wired up (visible in the Actions panel).
+ */
+export const WithActions: Story = {
+  args: {
+    onSearch: (keyword, zipCode) => console.log("Search:", keyword, zipCode),
+    onViewDetails: (id) => console.log("View details:", id),
+    onFavourite: (id) => console.log("Favourite:", id),
+    onViewAllCars: () => console.log("View all cars"),
+    onMakeClick: (make) => console.log("Make clicked:", make),
+    onSellClick: () => console.log("Sell click"),
+  },
+};

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -4,6 +4,7 @@ import {
   CarCard,
   CategoryCard,
   DashboardHero,
+  HeroStats,
   SectionHeader,
   SellBanner,
 } from "~/components";
@@ -66,64 +67,6 @@ const HOW_IT_WORKS_STEPS = [
       "Complete your purchase safely with our guided process and secure payment options.",
   },
 ];
-
-// ---------------------------------------------------------------------------
-// Section: Hero stats bar
-// ---------------------------------------------------------------------------
-
-function HeroStats() {
-  return (
-    <Box
-      sx={{
-        bgcolor: (t) => t.palette.custom.heroStatsBg,
-        py: 3,
-        px: 2,
-      }}
-    >
-      <Box
-        sx={{
-          maxWidth: 1456,
-          mx: "auto",
-          px: { xs: 2, md: 5 },
-          display: "flex",
-          justifyContent: "center",
-          gap: { xs: 4, md: 10 },
-          flexWrap: "wrap",
-        }}
-      >
-        {[
-          { value: "50K+", label: "Listings" },
-          { value: "12K+", label: "Dealers" },
-          { value: "98%", label: "Satisfaction" },
-        ].map(({ value, label }) => (
-          <Box key={label} sx={{ textAlign: "center" }}>
-            <Typography
-              sx={{
-                fontFamily: "'Barlow', sans-serif",
-                fontWeight: 700,
-                fontSize: { xs: 24, md: 32 },
-                color: (t) => t.palette.primary.contrastText,
-                lineHeight: 1,
-              }}
-            >
-              {value}
-            </Typography>
-            <Typography
-              sx={{
-                fontFamily: "'Inter', sans-serif",
-                fontSize: 14,
-                color: (t) => t.palette.custom.cardImagePlaceholder,
-                mt: 0.5,
-              }}
-            >
-              {label}
-            </Typography>
-          </Box>
-        ))}
-      </Box>
-    </Box>
-  );
-}
 
 // ---------------------------------------------------------------------------
 // Section: Why Choose Us

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,16 +1,377 @@
-import { Box, Container, Typography } from "@mui/material";
+import { Box, Stack, Typography } from "@mui/material";
+import {
+  AppFooter,
+  CarCard,
+  CategoryCard,
+  DashboardHero,
+  SectionHeader,
+  SellBanner,
+} from "~/components";
+import { useFilteredCars } from "~/data";
+import { Car } from "~/types";
 
-export function HomePage() {
+// ---------------------------------------------------------------------------
+// Static data for page sections
+// ---------------------------------------------------------------------------
+
+const POPULAR_MAKES = [
+  { emoji: "🚗", label: "BMW", listingCount: "2,400 listings" },
+  { emoji: "🚙", label: "Mercedes", listingCount: "1,980 listings" },
+  { emoji: "🏎️", label: "Audi", listingCount: "1,650 listings" },
+  { emoji: "🚕", label: "Lexus", listingCount: "1,200 listings" },
+  { emoji: "🚌", label: "Toyota", listingCount: "3,800 listings" },
+  { emoji: "⚡", label: "Tesla", listingCount: "900 listings" },
+];
+
+const FEATURE_CARDS = [
+  {
+    emoji: "✅",
+    label: "Verified Listings",
+    listingCount: "All listings are verified by our team",
+  },
+  {
+    emoji: "💰",
+    label: "Best Prices",
+    listingCount: "Competitive market pricing guaranteed",
+  },
+  {
+    emoji: "🔒",
+    label: "Secure Payments",
+    listingCount: "Safe and protected transactions",
+  },
+  {
+    emoji: "📋",
+    label: "Easy Management",
+    listingCount: "Manage your listings with ease",
+  },
+];
+
+const HOW_IT_WORKS_STEPS = [
+  {
+    step: "01",
+    title: "Search & Browse",
+    description:
+      "Use our powerful search and filter tools to find vehicles that match your needs and budget.",
+  },
+  {
+    step: "02",
+    title: "Connect with Sellers",
+    description:
+      "Contact verified dealers and private sellers directly through our secure messaging system.",
+  },
+  {
+    step: "03",
+    title: "Drive Away",
+    description:
+      "Complete your purchase safely with our guided process and secure payment options.",
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Section: Hero stats bar
+// ---------------------------------------------------------------------------
+
+function HeroStats() {
   return (
-    <Container maxWidth="lg">
-      <Box sx={{ py: 4 }}>
-        <Typography variant="h4" component="h1" gutterBottom>
-          Welcome to Autoshop
-        </Typography>
-        <Typography variant="body1" color="text.secondary">
-          Browse our selection of quality vehicles.
-        </Typography>
+    <Box
+      sx={{
+        bgcolor: "#1e293b",
+        py: 3,
+        px: 2,
+      }}
+    >
+      <Box
+        sx={{
+          maxWidth: 1456,
+          mx: "auto",
+          px: { xs: 2, md: 5 },
+          display: "flex",
+          justifyContent: "center",
+          gap: { xs: 4, md: 10 },
+          flexWrap: "wrap",
+        }}
+      >
+        {[
+          { value: "50K+", label: "Listings" },
+          { value: "12K+", label: "Dealers" },
+          { value: "98%", label: "Satisfaction" },
+        ].map(({ value, label }) => (
+          <Box key={label} sx={{ textAlign: "center" }}>
+            <Typography
+              sx={{
+                fontFamily: "'Barlow', sans-serif",
+                fontWeight: 700,
+                fontSize: { xs: 24, md: 32 },
+                color: "#ffffff",
+                lineHeight: 1,
+              }}
+            >
+              {value}
+            </Typography>
+            <Typography
+              sx={{
+                fontFamily: "'Inter', sans-serif",
+                fontSize: 14,
+                color: "#94a3b8",
+                mt: 0.5,
+              }}
+            >
+              {label}
+            </Typography>
+          </Box>
+        ))}
       </Box>
-    </Container>
+    </Box>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Section: Why Choose Us
+// ---------------------------------------------------------------------------
+
+function WhyChooseUsSection() {
+  return (
+    <Box component="section" sx={{ py: 8, px: 2, bgcolor: "#f8fafc" }}>
+      <Box sx={{ maxWidth: 1456, mx: "auto", px: { xs: 2, md: 5 } }}>
+        <SectionHeader title="Why Choose Us" />
+        <Stack
+          direction="row"
+          spacing={3}
+          sx={{ flexWrap: { xs: "wrap", md: "nowrap" } }}
+        >
+          {FEATURE_CARDS.map((card) => (
+            <CategoryCard
+              key={card.label}
+              emoji={card.emoji}
+              label={card.label}
+              listingCount={card.listingCount}
+            />
+          ))}
+        </Stack>
+      </Box>
+    </Box>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Section: Popular Makes
+// ---------------------------------------------------------------------------
+
+type PopularMakesSectionProps = {
+  onMakeClick?: (label: string) => void;
+};
+
+function PopularMakesSection({ onMakeClick }: PopularMakesSectionProps) {
+  return (
+    <Box component="section" sx={{ py: 8, px: 2, bgcolor: "#ffffff" }}>
+      <Box sx={{ maxWidth: 1456, mx: "auto", px: { xs: 2, md: 5 } }}>
+        <SectionHeader title="Popular Makes" />
+        <Stack
+          direction="row"
+          spacing={3}
+          sx={{ flexWrap: { xs: "wrap", md: "nowrap" } }}
+        >
+          {POPULAR_MAKES.map((make) => (
+            <CategoryCard
+              key={make.label}
+              emoji={make.emoji}
+              label={make.label}
+              listingCount={make.listingCount}
+              onClick={onMakeClick ? () => onMakeClick(make.label) : undefined}
+            />
+          ))}
+        </Stack>
+      </Box>
+    </Box>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Section: Trending Cars
+// ---------------------------------------------------------------------------
+
+type TrendingCarsSectionProps = {
+  cars: Car[];
+  onViewDetails: (id: string) => void;
+  onFavourite: (id: string) => void;
+  onViewAll?: () => void;
+};
+
+function TrendingCarsSection({
+  cars,
+  onViewDetails,
+  onFavourite,
+  onViewAll,
+}: TrendingCarsSectionProps) {
+  const trendingCars = cars.slice(0, 4);
+
+  return (
+    <Box component="section" sx={{ py: 8, px: 2, bgcolor: "#f8fafc" }}>
+      <Box sx={{ maxWidth: 1456, mx: "auto", px: { xs: 2, md: 5 } }}>
+        <SectionHeader title="Trending Cars" onViewAll={onViewAll} />
+        {trendingCars.length === 0 ? (
+          <Typography
+            sx={{ color: "#64748b", textAlign: "center", py: 6, fontSize: 16 }}
+          >
+            No listings available yet. Check back soon.
+          </Typography>
+        ) : (
+          <Stack
+            direction="row"
+            spacing={3}
+            sx={{ flexWrap: { xs: "wrap", md: "nowrap" } }}
+          >
+            {trendingCars.map((car, index) => (
+              <CarCard
+                key={car.id}
+                car={car}
+                onViewDetails={onViewDetails}
+                onFavourite={onFavourite}
+                featured={index === 0}
+                isNew={index === trendingCars.length - 1}
+              />
+            ))}
+          </Stack>
+        )}
+      </Box>
+    </Box>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Section: How It Works
+// ---------------------------------------------------------------------------
+
+function HowItWorksSection() {
+  return (
+    <Box component="section" sx={{ py: 8, px: 2, bgcolor: "#ffffff" }}>
+      <Box sx={{ maxWidth: 1456, mx: "auto", px: { xs: 2, md: 5 } }}>
+        <SectionHeader title="How It Works" />
+        <Stack
+          direction={{ xs: "column", md: "row" }}
+          spacing={4}
+          sx={{ mt: 1 }}
+        >
+          {HOW_IT_WORKS_STEPS.map((item) => (
+            <Box
+              key={item.step}
+              sx={{
+                flex: 1,
+                display: "flex",
+                flexDirection: "column",
+                alignItems: { xs: "center", md: "flex-start" },
+                textAlign: { xs: "center", md: "left" },
+              }}
+            >
+              <Box
+                sx={{
+                  width: 56,
+                  height: 56,
+                  bgcolor: "#dbeafe",
+                  borderRadius: "9999px",
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  mb: 2,
+                  flexShrink: 0,
+                }}
+              >
+                <Typography
+                  sx={{
+                    fontFamily: "'Barlow', sans-serif",
+                    fontWeight: 700,
+                    fontSize: 18,
+                    color: "#2563eb",
+                  }}
+                >
+                  {item.step}
+                </Typography>
+              </Box>
+
+              <Typography
+                sx={{
+                  fontFamily: "'Barlow', sans-serif",
+                  fontWeight: 600,
+                  fontSize: 20,
+                  color: "#0f172a",
+                  mb: 1,
+                }}
+              >
+                {item.title}
+              </Typography>
+
+              <Typography
+                sx={{
+                  fontFamily: "'Inter', sans-serif",
+                  fontWeight: 400,
+                  fontSize: 15,
+                  color: "#64748b",
+                  lineHeight: 1.6,
+                }}
+              >
+                {item.description}
+              </Typography>
+            </Box>
+          ))}
+        </Stack>
+      </Box>
+    </Box>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Page: HomePage
+// ---------------------------------------------------------------------------
+
+export type HomePageProps = {
+  onSearch?: (keyword: string, zipCode: string) => void;
+  onViewDetails?: (id: string) => void;
+  onFavourite?: (id: string) => void;
+  onViewAllCars?: () => void;
+  onMakeClick?: (make: string) => void;
+  onSellClick?: () => void;
+};
+
+export function HomePage({
+  onSearch,
+  onViewDetails = () => {},
+  onFavourite = () => {},
+  onViewAllCars,
+  onMakeClick,
+  onSellClick,
+}: HomePageProps) {
+  const cars = useFilteredCars();
+
+  return (
+    <Box component="main">
+      {/* Hero */}
+      <DashboardHero onSearch={onSearch} />
+
+      {/* Stats bar */}
+      <HeroStats />
+
+      {/* Why Choose Us */}
+      <WhyChooseUsSection />
+
+      {/* Popular Makes */}
+      <PopularMakesSection onMakeClick={onMakeClick} />
+
+      {/* Trending Cars */}
+      <TrendingCarsSection
+        cars={cars}
+        onViewDetails={onViewDetails}
+        onFavourite={onFavourite}
+        onViewAll={onViewAllCars}
+      />
+
+      {/* How It Works */}
+      <HowItWorksSection />
+
+      {/* Sell CTA */}
+      <SellBanner onSellClick={onSellClick} />
+
+      {/* Footer */}
+      <AppFooter />
+    </Box>
   );
 }

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -75,7 +75,7 @@ function HeroStats() {
   return (
     <Box
       sx={{
-        bgcolor: "#1e293b",
+        bgcolor: (t) => t.palette.custom.heroStatsBg,
         py: 3,
         px: 2,
       }}
@@ -102,7 +102,7 @@ function HeroStats() {
                 fontFamily: "'Barlow', sans-serif",
                 fontWeight: 700,
                 fontSize: { xs: 24, md: 32 },
-                color: "#ffffff",
+                color: (t) => t.palette.primary.contrastText,
                 lineHeight: 1,
               }}
             >
@@ -112,7 +112,7 @@ function HeroStats() {
               sx={{
                 fontFamily: "'Inter', sans-serif",
                 fontSize: 14,
-                color: "#94a3b8",
+                color: (t) => t.palette.custom.cardImagePlaceholder,
                 mt: 0.5,
               }}
             >
@@ -131,7 +131,7 @@ function HeroStats() {
 
 function WhyChooseUsSection() {
   return (
-    <Box component="section" sx={{ py: 8, px: 2, bgcolor: "#f8fafc" }}>
+    <Box component="section" sx={{ py: 8, px: 2, bgcolor: (t) => t.palette.background.default }}>
       <Box sx={{ maxWidth: 1456, mx: "auto", px: { xs: 2, md: 5 } }}>
         <SectionHeader title="Why Choose Us" />
         <Stack
@@ -163,7 +163,7 @@ type PopularMakesSectionProps = {
 
 function PopularMakesSection({ onMakeClick }: PopularMakesSectionProps) {
   return (
-    <Box component="section" sx={{ py: 8, px: 2, bgcolor: "#ffffff" }}>
+    <Box component="section" sx={{ py: 8, px: 2, bgcolor: (t) => t.palette.background.paper }}>
       <Box sx={{ maxWidth: 1456, mx: "auto", px: { xs: 2, md: 5 } }}>
         <SectionHeader title="Popular Makes" />
         <Stack
@@ -206,12 +206,12 @@ function TrendingCarsSection({
   const trendingCars = cars.slice(0, 4);
 
   return (
-    <Box component="section" sx={{ py: 8, px: 2, bgcolor: "#f8fafc" }}>
+    <Box component="section" sx={{ py: 8, px: 2, bgcolor: (t) => t.palette.background.default }}>
       <Box sx={{ maxWidth: 1456, mx: "auto", px: { xs: 2, md: 5 } }}>
         <SectionHeader title="Trending Cars" onViewAll={onViewAll} />
         {trendingCars.length === 0 ? (
           <Typography
-            sx={{ color: "#64748b", textAlign: "center", py: 6, fontSize: 16 }}
+            sx={{ color: (t) => t.palette.text.secondary, textAlign: "center", py: 6, fontSize: 16 }}
           >
             No listings available yet. Check back soon.
           </Typography>
@@ -244,7 +244,7 @@ function TrendingCarsSection({
 
 function HowItWorksSection() {
   return (
-    <Box component="section" sx={{ py: 8, px: 2, bgcolor: "#ffffff" }}>
+    <Box component="section" sx={{ py: 8, px: 2, bgcolor: (t) => t.palette.background.paper }}>
       <Box sx={{ maxWidth: 1456, mx: "auto", px: { xs: 2, md: 5 } }}>
         <SectionHeader title="How It Works" />
         <Stack
@@ -267,7 +267,7 @@ function HowItWorksSection() {
                 sx={{
                   width: 56,
                   height: 56,
-                  bgcolor: "#dbeafe",
+                  bgcolor: (t) => t.palette.custom.featuredBadgeBg,
                   borderRadius: "9999px",
                   display: "flex",
                   alignItems: "center",
@@ -281,7 +281,7 @@ function HowItWorksSection() {
                     fontFamily: "'Barlow', sans-serif",
                     fontWeight: 700,
                     fontSize: 18,
-                    color: "#2563eb",
+                    color: (t) => t.palette.custom.featuredBadgeText,
                   }}
                 >
                   {item.step}
@@ -293,7 +293,7 @@ function HowItWorksSection() {
                   fontFamily: "'Barlow', sans-serif",
                   fontWeight: 600,
                   fontSize: 20,
-                  color: "#0f172a",
+                  color: (t) => t.palette.text.primary,
                   mb: 1,
                 }}
               >
@@ -305,7 +305,7 @@ function HowItWorksSection() {
                   fontFamily: "'Inter', sans-serif",
                   fontWeight: 400,
                   fontSize: 15,
-                  color: "#64748b",
+                  color: (t) => t.palette.text.secondary,
                   lineHeight: 1.6,
                 }}
               >

--- a/src/storybooks/index.ts
+++ b/src/storybooks/index.ts
@@ -10,9 +10,10 @@
 import type { Decorator } from "@storybook/react";
 import { ThemeProvider } from "@mui/material/styles";
 import CssBaseline from "@mui/material/CssBaseline";
-import React from "react";
+import React, { useEffect } from "react";
 import type { Car } from "~/types";
 import theme from "~/theme";
+import { useSetCars } from "~/data";
 
 // ---------------------------------------------------------------------------
 // Theme decorator — wraps stories in the app's MUI theme
@@ -26,6 +27,82 @@ export const withTheme: Decorator = (Story: any) =>
     React.createElement(CssBaseline),
     React.createElement(Story)
   );
+
+// ---------------------------------------------------------------------------
+// Store decorator — seeds the Zustand store with mock car data
+// ---------------------------------------------------------------------------
+
+/** A set of mock cars used to seed the Zustand store in Storybook stories. */
+const STORE_MOCK_CARS: Car[] = [
+  {
+    id: "s1",
+    make: "Toyota",
+    model: "Corolla",
+    year: 2021,
+    price: 22000,
+    mileage: 18000,
+    color: "Silver",
+    fuelType: "petrol",
+    transmission: "automatic",
+    description: "A reliable and fuel-efficient sedan.",
+    imageUrl: "https://placehold.co/600x400?text=Toyota+Corolla",
+  },
+  {
+    id: "s2",
+    make: "Tesla",
+    model: "Model 3",
+    year: 2023,
+    price: 42000,
+    mileage: 5000,
+    color: "White",
+    fuelType: "electric",
+    transmission: "automatic",
+    description: "A long-range electric sedan with Autopilot.",
+    imageUrl: "https://placehold.co/600x400?text=Tesla+Model+3",
+  },
+  {
+    id: "s3",
+    make: "BMW",
+    model: "3 Series",
+    year: 2020,
+    price: 35000,
+    mileage: 28000,
+    color: "Black",
+    fuelType: "petrol",
+    transmission: "automatic",
+    description: "A premium sports sedan.",
+    imageUrl: "https://placehold.co/600x400?text=BMW+3+Series",
+  },
+  {
+    id: "s4",
+    make: "Toyota",
+    model: "Prius",
+    year: 2022,
+    price: 31000,
+    mileage: 12000,
+    color: "Green",
+    fuelType: "hybrid",
+    transmission: "automatic",
+    description: "The iconic hybrid hatchback.",
+    imageUrl: "https://placehold.co/600x400?text=Toyota+Prius",
+  },
+];
+
+function StoreSeeder({ children }: { children: React.ReactNode }) {
+  const setCars = useSetCars();
+  useEffect(() => {
+    setCars(STORE_MOCK_CARS);
+  }, [setCars]);
+  return React.createElement(React.Fragment, null, children);
+}
+
+/**
+ * Wraps a story with a pre-seeded Zustand store so components that read
+ * from the store (e.g. `useFilteredCars`) have data to display.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const withMockStore: Decorator = (Story: any) =>
+  React.createElement(StoreSeeder, null, React.createElement(Story));
 
 // ---------------------------------------------------------------------------
 // Mock data helpers

--- a/src/theme/README.md
+++ b/src/theme/README.md
@@ -45,6 +45,7 @@ These extend MUI's palette via TypeScript module augmentation (see bottom of `in
 | `palette.custom.cardImagePlaceholder` | `#94a3b8` | Car card image placeholder icon fill |
 | `palette.custom.divider` | `#e2e8f0` | Horizontal/vertical dividers |
 | `palette.custom.navbarBg` | `#0f172a` | Top navbar background |
+| `palette.custom.heroStatsBg` | `#1e293b` | Hero stats bar background (slate-800) |
 
 ---
 

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -56,6 +56,7 @@ const theme = createTheme({
       cardImagePlaceholder: "#94a3b8",
       divider: "#e2e8f0",
       navbarBg: "#0f172a",
+      heroStatsBg: "#1e293b",
     },
   },
 
@@ -101,6 +102,7 @@ declare module "@mui/material/styles" {
       cardImagePlaceholder: string;
       divider: string;
       navbarBg: string;
+      heroStatsBg: string;
     };
   }
   interface PaletteOptions {
@@ -112,6 +114,7 @@ declare module "@mui/material/styles" {
       cardImagePlaceholder?: string;
       divider?: string;
       navbarBg?: string;
+      heroStatsBg?: string;
     };
   }
 }


### PR DESCRIPTION
## Summary

- Composes the `HomePage` from existing components: `DashboardHero`, `CategoryCard`, `CarCard`, `SectionHeader`, `SellBanner`, `AppFooter`
- Implements all sections from the Figma spec: hero with stats bar, Why Choose Us feature cards, Popular Makes brand grid, Trending Cars (wired from `useFilteredCars` store hook), How It Works 3-step process, Sell CTA, and footer
- Adds a `withMockStore` Storybook decorator to `~/storybooks` that seeds the Zustand store so store-connected components render correctly in stories
- Exports `HomePageProps` with full callback props for navigation, search, favourites, and sell actions
- Storybook stories cover `Default` (full-page render) and `WithActions` (Actions panel wiring)
- Replaced all hardcoded hex color values with MUI theme tokens (sx callback pattern)
- Added `palette.custom.heroStatsBg` token for hero stats bar background (slate-800 / #1e293b)
- Resolved merge conflict with latest main

Closes #12

🤖 Generated by UI Agent