### PR TITLE
feat(ui): build new listing page and form with Storybook stories

### DIFF
--- a/src/components/NewListingForm.mdx
+++ b/src/components/NewListingForm.mdx
@@ -1,0 +1,57 @@
+{/* src/components/NewListingForm.mdx */}
+
+import { Meta, Canvas, Controls } from "@storybook/addon-docs/blocks";
+import * as NewListingFormStories from "./NewListingForm.stories";
+
+<Meta of={NewListingFormStories} />
+
+# NewListingForm
+
+A controlled form component for sellers to create a new car listing. Covers all required car
+details: make, model, year, price, mileage, colour, fuel type, transmission, description, and
+an image URL field with a drag-and-drop placeholder area.
+
+## Usage
+
+<Canvas of={NewListingFormStories.Default} />
+<Controls of={NewListingFormStories.Default} />
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `initialValues` | `Partial<NewListingFormValues>` | `{}` | Pre-populate fields (edit mode or review state). |
+| `errors` | `NewListingFormErrors` | `{}` | Validation errors keyed by field name — displayed as helper text below each field. |
+| `onSubmit` | `(values: NewListingFormValues) => void` | — | Called with current form values when the seller submits. |
+| `onCancel` | `() => void` | — | Called when the seller clicks the Cancel button. |
+| `isSubmitting` | `boolean` | `false` | Disables the submit button and shows "Publishing..." label while the form is being submitted. |
+
+## Variants
+
+### Validation errors
+
+<Canvas of={NewListingFormStories.WithValidationErrors} />
+
+Shows error messages beneath each required field. Pass a `errors` object keyed by field name.
+
+### Prefilled
+
+<Canvas of={NewListingFormStories.Prefilled} />
+
+Demonstrates edit-mode or review-before-publish by pre-populating all fields via `initialValues`.
+
+### Submitting
+
+<Canvas of={NewListingFormStories.Submitting} />
+
+The submit button is disabled and labelled "Publishing..." while `isSubmitting` is `true`.
+The Cancel button is also disabled to prevent abandonment mid-submit.
+
+## Design notes
+
+- All colours come from the MUI theme — no hardcoded hex values.
+- Fuel type and transmission use MUI `Select` with an accessible `InputLabel` / `labelId` pairing.
+- The image upload area is a visual placeholder only; drag-and-drop is not yet implemented.
+  Sellers can paste an image URL into the text field instead.
+- The form uses `noValidate` on the `<form>` element so browser-native validation is suppressed
+  in favour of the `errors` prop-driven approach.

--- a/src/components/NewListingForm.stories.tsx
+++ b/src/components/NewListingForm.stories.tsx
@@ -1,0 +1,91 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Box } from "@mui/material";
+import { NewListingForm } from "./NewListingForm";
+import { withTheme } from "~/storybooks";
+
+const meta: Meta<typeof NewListingForm> = {
+  title: "Components/NewListingForm",
+  component: NewListingForm,
+  decorators: [
+    withTheme,
+    (Story) => (
+      <Box sx={{ p: 4, maxWidth: 800, mx: "auto" }}>
+        <Story />
+      </Box>
+    ),
+  ],
+  argTypes: {
+    onSubmit: { action: "onSubmit" },
+    onCancel: { action: "onCancel" },
+    isSubmitting: { control: "boolean" },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof NewListingForm>;
+
+/**
+ * Empty form — the initial state a seller sees when they open the new listing page.
+ */
+export const Default: Story = {};
+
+/**
+ * Validation errors — shown after the seller attempts to submit an incomplete form.
+ * All required fields have error messages so reviewers can verify the error display.
+ */
+export const WithValidationErrors: Story = {
+  args: {
+    errors: {
+      make: "Make is required.",
+      model: "Model is required.",
+      year: "Please enter a valid year.",
+      price: "Price must be greater than 0.",
+      mileage: "Mileage is required.",
+      fuelType: "Please select a fuel type.",
+      transmission: "Please select a transmission type.",
+    },
+  },
+};
+
+/**
+ * Pre-populated form — represents an edit-mode or review-before-publish state.
+ */
+export const Prefilled: Story = {
+  args: {
+    initialValues: {
+      make: "Toyota",
+      model: "Camry",
+      year: "2023",
+      price: "28500",
+      mileage: "12000",
+      fuelType: "petrol",
+      transmission: "automatic",
+      color: "Silver",
+      description:
+        "Well-maintained one-owner vehicle. Full service history. No accidents. Includes all-weather floor mats and roof rack.",
+      imageUrl:
+        "https://images.unsplash.com/photo-1494976388531-d1058494cdd8?w=680&q=80",
+    },
+  },
+};
+
+/**
+ * Submitting state — the submit button is disabled and shows a loading label.
+ */
+export const Submitting: Story = {
+  args: {
+    isSubmitting: true,
+    initialValues: {
+      make: "Honda",
+      model: "Civic",
+      year: "2022",
+      price: "21000",
+      mileage: "18500",
+      fuelType: "petrol",
+      transmission: "manual",
+      color: "Blue",
+      description: "Great condition, single owner.",
+    },
+  },
+};

--- a/src/components/NewListingForm.tsx
+++ b/src/components/NewListingForm.tsx
@@ -1,0 +1,355 @@
+import {
+  Box,
+  Button,
+  FormControl,
+  FormHelperText,
+  InputLabel,
+  MenuItem,
+  Select,
+  Stack,
+  TextField,
+  Typography,
+} from "@mui/material";
+import CloudUploadIcon from "@mui/icons-material/CloudUpload";
+import React, { useState } from "react";
+import type { FuelType, Transmission } from "~/types";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type NewListingFormValues = {
+  make: string;
+  model: string;
+  year: string;
+  price: string;
+  mileage: string;
+  fuelType: FuelType | "";
+  transmission: Transmission | "";
+  color: string;
+  description: string;
+  imageUrl: string;
+};
+
+export type NewListingFormErrors = Partial<Record<keyof NewListingFormValues, string>>;
+
+export type NewListingFormProps = {
+  /** Initial field values — useful for pre-populating in stories or edit mode. */
+  initialValues?: Partial<NewListingFormValues>;
+  /** Validation errors to display on each field. */
+  errors?: NewListingFormErrors;
+  /** Called with the current form values when the seller submits. */
+  onSubmit?: (values: NewListingFormValues) => void;
+  /** Called when the seller clicks Cancel. */
+  onCancel?: () => void;
+  /** While true the submit button shows a loading state. */
+  isSubmitting?: boolean;
+};
+
+const EMPTY_VALUES: NewListingFormValues = {
+  make: "",
+  model: "",
+  year: "",
+  price: "",
+  mileage: "",
+  fuelType: "",
+  transmission: "",
+  color: "",
+  description: "",
+  imageUrl: "",
+};
+
+const FUEL_TYPE_OPTIONS: { value: FuelType; label: string }[] = [
+  { value: "petrol", label: "Petrol" },
+  { value: "diesel", label: "Diesel" },
+  { value: "electric", label: "Electric" },
+  { value: "hybrid", label: "Hybrid" },
+];
+
+const TRANSMISSION_OPTIONS: { value: Transmission; label: string }[] = [
+  { value: "manual", label: "Manual" },
+  { value: "automatic", label: "Automatic" },
+];
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function NewListingForm({
+  initialValues,
+  errors = {},
+  onSubmit,
+  onCancel,
+  isSubmitting = false,
+}: NewListingFormProps) {
+  const [values, setValues] = useState<NewListingFormValues>({
+    ...EMPTY_VALUES,
+    ...initialValues,
+  });
+
+  function handleChange(field: keyof NewListingFormValues, value: string) {
+    setValues((prev) => ({ ...prev, [field]: value }));
+  }
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    onSubmit?.(values);
+  }
+
+  return (
+    <Box
+      component="form"
+      onSubmit={handleSubmit}
+      noValidate
+      sx={{
+        bgcolor: (t) => t.palette.background.paper,
+        borderRadius: (t) => `${(t.shape.borderRadius as number) * 2}px`,
+        border: "1px solid",
+        borderColor: (t) => t.palette.custom.divider,
+        p: { xs: 3, md: 5 },
+      }}
+    >
+      {/* Section: Car Details */}
+      <Typography
+        variant="h3"
+        sx={{ mb: 3, color: (t) => t.palette.text.primary }}
+      >
+        Car Details
+      </Typography>
+
+      <Stack spacing={3}>
+        {/* Row: Make + Model */}
+        <Stack direction={{ xs: "column", sm: "row" }} spacing={2}>
+          <TextField
+            label="Make"
+            placeholder="e.g. Toyota"
+            fullWidth
+            required
+            value={values.make}
+            onChange={(e) => handleChange("make", e.target.value)}
+            error={Boolean(errors.make)}
+            helperText={errors.make}
+            inputProps={{ "aria-label": "Car make" }}
+          />
+          <TextField
+            label="Model"
+            placeholder="e.g. Camry"
+            fullWidth
+            required
+            value={values.model}
+            onChange={(e) => handleChange("model", e.target.value)}
+            error={Boolean(errors.model)}
+            helperText={errors.model}
+            inputProps={{ "aria-label": "Car model" }}
+          />
+        </Stack>
+
+        {/* Row: Year + Price */}
+        <Stack direction={{ xs: "column", sm: "row" }} spacing={2}>
+          <TextField
+            label="Year"
+            placeholder="e.g. 2023"
+            fullWidth
+            required
+            type="number"
+            value={values.year}
+            onChange={(e) => handleChange("year", e.target.value)}
+            error={Boolean(errors.year)}
+            helperText={errors.year}
+            inputProps={{ min: 1900, max: 2100, "aria-label": "Year of manufacture" }}
+          />
+          <TextField
+            label="Price ($)"
+            placeholder="e.g. 28500"
+            fullWidth
+            required
+            type="number"
+            value={values.price}
+            onChange={(e) => handleChange("price", e.target.value)}
+            error={Boolean(errors.price)}
+            helperText={errors.price}
+            inputProps={{ min: 0, "aria-label": "Listing price in dollars" }}
+          />
+        </Stack>
+
+        {/* Row: Mileage + Color */}
+        <Stack direction={{ xs: "column", sm: "row" }} spacing={2}>
+          <TextField
+            label="Mileage (mi)"
+            placeholder="e.g. 12000"
+            fullWidth
+            required
+            type="number"
+            value={values.mileage}
+            onChange={(e) => handleChange("mileage", e.target.value)}
+            error={Boolean(errors.mileage)}
+            helperText={errors.mileage}
+            inputProps={{ min: 0, "aria-label": "Odometer reading in miles" }}
+          />
+          <TextField
+            label="Color"
+            placeholder="e.g. Silver"
+            fullWidth
+            value={values.color}
+            onChange={(e) => handleChange("color", e.target.value)}
+            error={Boolean(errors.color)}
+            helperText={errors.color}
+            inputProps={{ "aria-label": "Exterior colour" }}
+          />
+        </Stack>
+
+        {/* Row: Fuel Type + Transmission */}
+        <Stack direction={{ xs: "column", sm: "row" }} spacing={2}>
+          <FormControl fullWidth required error={Boolean(errors.fuelType)}>
+            <InputLabel id="fuel-type-label">Fuel Type</InputLabel>
+            <Select
+              labelId="fuel-type-label"
+              label="Fuel Type"
+              value={values.fuelType}
+              onChange={(e) => handleChange("fuelType", e.target.value)}
+              inputProps={{ "aria-label": "Fuel type" }}
+            >
+              {FUEL_TYPE_OPTIONS.map((opt) => (
+                <MenuItem key={opt.value} value={opt.value}>
+                  {opt.label}
+                </MenuItem>
+              ))}
+            </Select>
+            {errors.fuelType && (
+              <FormHelperText>{errors.fuelType}</FormHelperText>
+            )}
+          </FormControl>
+
+          <FormControl fullWidth required error={Boolean(errors.transmission)}>
+            <InputLabel id="transmission-label">Transmission</InputLabel>
+            <Select
+              labelId="transmission-label"
+              label="Transmission"
+              value={values.transmission}
+              onChange={(e) => handleChange("transmission", e.target.value)}
+              inputProps={{ "aria-label": "Transmission type" }}
+            >
+              {TRANSMISSION_OPTIONS.map((opt) => (
+                <MenuItem key={opt.value} value={opt.value}>
+                  {opt.label}
+                </MenuItem>
+              ))}
+            </Select>
+            {errors.transmission && (
+              <FormHelperText>{errors.transmission}</FormHelperText>
+            )}
+          </FormControl>
+        </Stack>
+
+        {/* Description */}
+        <TextField
+          label="Description"
+          placeholder="Describe the car's condition, features, history, etc."
+          fullWidth
+          multiline
+          minRows={4}
+          value={values.description}
+          onChange={(e) => handleChange("description", e.target.value)}
+          error={Boolean(errors.description)}
+          helperText={errors.description}
+          inputProps={{ "aria-label": "Car description" }}
+        />
+
+        {/* Image Upload */}
+        <Box>
+          <Typography
+            variant="body2"
+            sx={{ mb: 1, color: (t) => t.palette.text.primary, fontWeight: 600 }}
+          >
+            Images
+          </Typography>
+          <TextField
+            label="Image URL"
+            placeholder="https://example.com/car-photo.jpg"
+            fullWidth
+            value={values.imageUrl}
+            onChange={(e) => handleChange("imageUrl", e.target.value)}
+            error={Boolean(errors.imageUrl)}
+            helperText={errors.imageUrl ?? "Paste a direct link to a photo of your car."}
+            inputProps={{ "aria-label": "Car image URL" }}
+          />
+
+          {/* Upload placeholder area */}
+          <Box
+            sx={{
+              mt: 2,
+              height: 120,
+              border: "2px dashed",
+              borderColor: (t) => t.palette.custom.divider,
+              borderRadius: (t) => `${t.shape.borderRadius}px`,
+              display: "flex",
+              flexDirection: "column",
+              alignItems: "center",
+              justifyContent: "center",
+              gap: 1,
+              bgcolor: (t) => t.palette.background.default,
+              cursor: "not-allowed",
+            }}
+            aria-label="Image upload area (not yet implemented)"
+          >
+            <CloudUploadIcon sx={{ fontSize: 32, color: (t) => t.palette.text.secondary }} />
+            <Typography variant="body2" sx={{ color: (t) => t.palette.text.secondary }}>
+              Drag and drop coming soon — use the URL field above
+            </Typography>
+          </Box>
+        </Box>
+
+        {/* Actions */}
+        <Stack direction="row" spacing={2} justifyContent="flex-end" sx={{ pt: 1 }}>
+          <Button
+            variant="outlined"
+            onClick={onCancel}
+            disabled={isSubmitting}
+            sx={{
+              borderColor: (t) => t.palette.custom.divider,
+              borderWidth: 2,
+              color: (t) => t.palette.text.primary,
+              fontWeight: 600,
+              borderRadius: (t) => `${t.shape.borderRadius}px`,
+              height: 45,
+              px: 3,
+              textTransform: "none",
+              "&:hover": {
+                borderColor: (t) => t.palette.text.secondary,
+                borderWidth: 2,
+                bgcolor: "transparent",
+              },
+            }}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="submit"
+            variant="contained"
+            disabled={isSubmitting}
+            sx={{
+              bgcolor: (t) => t.palette.primary.main,
+              color: (t) => t.palette.primary.contrastText,
+              fontWeight: 600,
+              borderRadius: (t) => `${t.shape.borderRadius}px`,
+              height: 45,
+              px: 4,
+              textTransform: "none",
+              boxShadow: "none",
+              "&:hover": {
+                bgcolor: (t) => t.palette.primary.dark,
+                boxShadow: "none",
+              },
+              "&:disabled": {
+                bgcolor: (t) => t.palette.text.secondary,
+                color: (t) => t.palette.background.paper,
+              },
+            }}
+          >
+            {isSubmitting ? "Publishing…" : "Publish Listing"}
+          </Button>
+        </Stack>
+      </Stack>
+    </Box>
+  );
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -16,3 +16,5 @@ export { SectionHeader } from './SectionHeader';
 export type { SectionHeaderProps } from './SectionHeader';
 export { SellBanner } from './SellBanner';
 export type { SellBannerProps } from './SellBanner';
+export { NewListingForm } from './NewListingForm';
+export type { NewListingFormProps, NewListingFormValues, NewListingFormErrors } from './NewListingForm';

--- a/src/pages/NewListingPage.mdx
+++ b/src/pages/NewListingPage.mdx
@@ -1,0 +1,55 @@
+{/* src/pages/NewListingPage.mdx */}
+
+import { Meta, Canvas } from "@storybook/addon-docs/blocks";
+import * as NewListingPageStories from "./NewListingPage.stories";
+
+<Meta of={NewListingPageStories} />
+
+# NewListingPage
+
+The full-page view for sellers to create a new car listing. Composes the `DashboardHeader`,
+a page heading section, the `NewListingForm` component, and the `AppFooter`.
+
+## Usage
+
+<Canvas of={NewListingPageStories.Default} />
+
+## Submitting state
+
+<Canvas of={NewListingPageStories.Submitting} />
+
+Rendered while the form submission is in progress. The submit button in `NewListingForm` is
+disabled and labelled "Publishing..." so the seller gets clear feedback.
+
+## Page structure
+
+| Section | Component | Description |
+|---------|-----------|-------------|
+| Header | `DashboardHeader` | Navigation bar with logo, links, and account actions. |
+| Heading | inline `Typography` | Page title and sub-title above the form. |
+| Form | `NewListingForm` | Car details form with validation-error support. |
+| Footer | `AppFooter` | Site-wide footer with links and copyright. |
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `onSubmit` | `(values: NewListingFormValues) => void` | — | Forwarded to `NewListingForm`. Called when the seller submits. |
+| `onCancel` | `() => void` | — | Forwarded to `NewListingForm`. Called on Cancel click. |
+| `isSubmitting` | `boolean` | `false` | Forwarded to `NewListingForm`. Shows loading state on submit button. |
+| `onSignIn` | `() => void` | — | Forwarded to `DashboardHeader`. |
+| `onNavLinkClick` | `(href: string) => void` | — | Forwarded to `DashboardHeader`. |
+
+## Router context
+
+`DashboardHeader` uses `useNavigate` internally. In Storybook the page is wrapped with a
+`createRoutesStub` decorator to provide the required router context. In the application it
+is rendered inside `RootLayout`.
+
+## Design notes
+
+- The page uses `minHeight: 100vh` with `flexDirection: column` and `flex: 1` on `main` so the
+  footer always anchors to the bottom even on short content.
+- All colours are sourced from the MUI theme palette — no hardcoded hex values.
+- Form validation is driven externally via the `errors` prop on `NewListingForm`. Wire up a
+  validation library (e.g. Zod + react-hook-form) in the route handler before passing errors down.

--- a/src/pages/NewListingPage.stories.tsx
+++ b/src/pages/NewListingPage.stories.tsx
@@ -1,0 +1,47 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import React from "react";
+import type { Decorator } from "@storybook/react";
+import { createRoutesStub } from "react-router";
+import { NewListingPage } from "./NewListingPage";
+import { withTheme } from "~/storybooks";
+
+const withRouter: Decorator = (Story) => {
+  const Stub = createRoutesStub([{ path: "/", Component: Story }]);
+  return React.createElement(Stub, { initialEntries: ["/"] });
+};
+
+const meta: Meta<typeof NewListingPage> = {
+  title: "Pages/NewListingPage",
+  component: NewListingPage,
+  decorators: [withTheme, withRouter],
+  parameters: {
+    layout: "fullscreen",
+  },
+  argTypes: {
+    onSubmit: { action: "onSubmit" },
+    onCancel: { action: "onCancel" },
+    onSignIn: { action: "onSignIn" },
+    onNavLinkClick: { action: "onNavLinkClick" },
+    isSubmitting: { control: "boolean" },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof NewListingPage>;
+
+/**
+ * Default full-page render — the empty form a seller sees when they first
+ * navigate to the new listing page.
+ */
+export const Default: Story = {};
+
+/**
+ * Submitting state — the form is mid-submit. The submit button is disabled
+ * and shows "Publishing..." to give the seller clear feedback.
+ */
+export const Submitting: Story = {
+  args: {
+    isSubmitting: true,
+  },
+};

--- a/src/pages/NewListingPage.tsx
+++ b/src/pages/NewListingPage.tsx
@@ -1,0 +1,75 @@
+import { Box, Container, Typography } from "@mui/material";
+import { AppFooter, DashboardHeader, NewListingForm } from "~/components";
+import type { NewListingFormValues } from "~/components";
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+export type NewListingPageProps = {
+  /** Called when the seller submits the completed form. */
+  onSubmit?: (values: NewListingFormValues) => void;
+  /** Called when the seller clicks Cancel on the form. */
+  onCancel?: () => void;
+  /** While true the form submit button shows a loading/disabled state. */
+  isSubmitting?: boolean;
+  /** Called when the Sign In button in the header is clicked. */
+  onSignIn?: () => void;
+  /** Called when a nav link in the header is clicked. */
+  onNavLinkClick?: (href: string) => void;
+};
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function NewListingPage({
+  onSubmit,
+  onCancel,
+  isSubmitting = false,
+  onSignIn,
+  onNavLinkClick,
+}: NewListingPageProps) {
+  return (
+    <Box
+      sx={{
+        minHeight: "100vh",
+        bgcolor: (t) => t.palette.background.default,
+        display: "flex",
+        flexDirection: "column",
+      }}
+    >
+      {/* Header */}
+      <DashboardHeader onSignIn={onSignIn} onNavLinkClick={onNavLinkClick} />
+
+      {/* Page content */}
+      <Box component="main" sx={{ flex: 1, py: { xs: 4, md: 7 } }}>
+        <Container maxWidth="md">
+          {/* Page heading */}
+          <Typography
+            variant="h2"
+            sx={{ mb: 1, color: (t) => t.palette.text.primary }}
+          >
+            Create a New Listing
+          </Typography>
+          <Typography
+            variant="body1"
+            sx={{ mb: 4, color: (t) => t.palette.text.secondary }}
+          >
+            Fill in the details below to publish your car listing on AutoExchange.
+          </Typography>
+
+          {/* Form */}
+          <NewListingForm
+            onSubmit={onSubmit}
+            onCancel={onCancel}
+            isSubmitting={isSubmitting}
+          />
+        </Container>
+      </Box>
+
+      {/* Footer */}
+      <AppFooter />
+    </Box>
+  );
+}

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -3,3 +3,5 @@ export { DashboardPage } from "./DashboardPage";
 export type { DashboardPageProps } from "./DashboardPage";
 export { HomePage } from "./HomePage";
 export { NotFoundPage } from "./NotFoundPage";
+export { NewListingPage } from "./NewListingPage";
+export type { NewListingPageProps } from "./NewListingPage";


### PR DESCRIPTION
## Summary

- Add `NewListingForm` component with all car detail fields: make, model, year, price, mileage, colour, fuel type, transmission, description, and image URL
- Add Storybook stories for `NewListingForm`: `Default` (empty), `WithValidationErrors`, `Prefilled`, and `Submitting` states
- Add `NewListingPage` wrapper that composes `DashboardHeader`, the form, and `AppFooter` — the full page a seller sees
- Add Storybook stories for `NewListingPage`: `Default` and `Submitting`
- Add MDX documentation for both `NewListingForm` and `NewListingPage`
- Export both components from their barrel files (`src/components/index.ts`, `src/pages/index.ts`)
- Fix a TypeScript error in `NewListingForm` — `t.shape.borderRadius` cast to `number` before multiplication

Closes #41

🤖 Generated by UI Agent